### PR TITLE
Fix async fixture decorators and close issue #60

### DIFF
--- a/implementation_plans/fix_issue_60_spec.md
+++ b/implementation_plans/fix_issue_60_spec.md
@@ -1,0 +1,100 @@
+# Fix Pre-existing Test Failures — Issue #60 Specification
+
+**Issue:** [#60](https://github.com/lbnl-science-it/WorkJournalMaker/issues/60)
+**Scope:** 11 test files, ~130 failures + ~18 errors on `main`
+**Out of scope:** `test_local_build.py` (39 failures) — separate issue
+
+## Problem Statement
+
+157 test failures and 18 errors exist on `main` across 11 test files. These failures pre-date the Cluster A-F metaplan work and are unrelated to recent feature development. The tested code (WorkWeekService, CalendarService, EntryManager, etc.) is real and actively used — the tests themselves have wiring issues.
+
+## Root Cause Categories
+
+### Category 1: Async Fixture Decorator Misuse (~100+ failures)
+
+**Files affected:**
+- `tests/test_work_week_compatibility.py` (~20 failures)
+- `tests/test_work_week_database_sync.py` (~12 failures)
+- `tests/test_work_week_integration.py` (1 failure)
+- `tests/test_work_week_performance.py` (~5 failures + 4 errors)
+- `tests/test_calendar_interface_step14.py` (1 failure + 6 errors)
+- `tests/test_calendar_service_integration.py` (~3 errors)
+- `tests/test_web_integration.py` (1 failure + 5 errors)
+
+**Root cause:** Tests use `@pytest.fixture` with `async def`, but `pytest-asyncio` in strict mode requires `@pytest_asyncio.fixture`. Sync test functions receive coroutine objects instead of resolved values, causing `TypeError: 'async_generator' object is not subscriptable`.
+
+**Fix:** Replace `@pytest.fixture` with `@pytest_asyncio.fixture` on all async fixture functions in affected files. Add `import pytest_asyncio` where missing.
+
+### Category 2: Test-Code Contract Mismatches (~15 failures)
+
+**Files affected:**
+- `tests/test_work_week_service.py` (~10 failures)
+- `tests/test_work_week_settings_service.py` (1 failure)
+- `tests/test_build_config.py` (2 failures)
+- `tests/test_settings_persistence.py` (3 failures)
+
+**Root cause:** Tests construct invalid `WorkWeekConfig` objects expecting to test validation logic, but `__post_init__` raises `ValueError` before the validation method under test is reached. Similarly, `validate_config()` raises `BuildConfigError` instead of returning `False` as tests expect.
+
+**Fix approach — evaluate both sides:**
+1. Examine whether `__post_init__` validation is architecturally appropriate or if validation should live in a separate method that tests can call independently.
+2. If `__post_init__` validation is correct: restructure tests to use `pytest.raises` for constructor validation, testing at the right layer.
+3. If validation should be separated: refactor the production code and update tests accordingly.
+4. For `validate_config()`: determine if raising vs returning `False` is the correct behavior, then align tests.
+
+### Category 3: Async Test Runner Setup/Teardown Errors (~18 errors)
+
+**Files affected:** Same as Category 1 (calendar, web integration tests).
+
+**Root cause:** Database setup fixtures fail during async collection, preventing test execution.
+
+**Fix:** Expected to resolve automatically once Category 1 fixtures are corrected.
+
+## Implementation Plan
+
+### Phase 1: Async Fixture Fixes (Category 1 + Category 3)
+
+1. Identify all async fixtures using `@pytest.fixture` in the 7 affected files
+2. Replace with `@pytest_asyncio.fixture`
+3. Add `import pytest_asyncio` where missing
+4. Run full test suite — verify Category 1 and Category 3 failures resolve
+5. **Commit:** "Fix async fixture decorators in work week, calendar, and web tests (#60)"
+
+### Phase 2: Contract Mismatch Fixes (Category 2)
+
+1. Read `WorkWeekConfig.__post_init__` and the failing tests to understand the contract gap
+2. Evaluate whether `__post_init__` validation is the right design:
+   - If yes: update tests to use `pytest.raises` at constructor level
+   - If no: refactor validation into a separate callable method
+3. Fix `validate_config()` / `BuildConfigError` test expectations
+4. Fix `test_settings_persistence.py` database setup issues
+5. Run full test suite — verify Category 2 failures resolve
+6. **Commit:** "Fix test-code contract mismatches in validation tests (#60)"
+
+### Phase 3: Verification and Cleanup
+
+1. Run full test suite — confirm all #60 scope tests pass or are justified `xfail`
+2. If any tests cover genuinely unimplemented functionality, mark `@pytest.mark.xfail(reason="...")` with a clear reason
+3. **Commit:** "Mark unimplemented feature tests as xfail (#60)" (if applicable)
+4. Update issue #60 with results
+
+## Success Criteria
+
+- All tests in the 11 files listed in #60 either **pass** or are marked `xfail` with justification
+- No test deletions without explicit approval
+- No production code changes unless the Category 2 evaluation determines `__post_init__` validation should be restructured
+- Full test suite run shows improvement from current baseline (169 failed → target: <40 remaining from out-of-scope `test_local_build.py`)
+
+## Verification Commands
+
+```bash
+# Run just the #60 scope
+pytest tests/test_work_week_service.py tests/test_work_week_compatibility.py \
+  tests/test_work_week_database_sync.py tests/test_work_week_integration.py \
+  tests/test_work_week_performance.py tests/test_work_week_settings_service.py \
+  tests/test_calendar_interface_step14.py tests/test_calendar_service_integration.py \
+  tests/test_web_integration.py tests/test_build_config.py \
+  tests/test_settings_persistence.py --tb=short -q
+
+# Full suite baseline comparison
+pytest -v --tb=line 2>&1 | tail -5
+```

--- a/plan.md
+++ b/plan.md
@@ -129,29 +129,14 @@ Commit: "Verify Phase 1 async fixture fixes (#60, step 1.4)" (if any additional 
 
 ---
 
-## Decision Gate: Evaluate Phase 2
+## Decision Gate: Result
 
-**After Phase 1 completes, answer these questions:**
+**Recovery rate: 11%** (6 of 55 broken tests). Below the 50% threshold.
 
-1. How many of the 55 broken tests now pass?
-2. Of those that still fail, are the failures shallow (assertion tweaks) or deep (fundamentally wrong test design)?
-3. Is the signal-to-noise improvement from Phase 1 alone sufficient?
+Findings:
+- Only 2 of 7 files had async fixture decorator issues (the original spec was wrong)
+- Remaining failures: stale API signatures, removed model columns, fixture scoping bugs
+- Tests were never validated against production code
 
-**If >80% pass:** Proceed with Phase 2 — the tests have value, just wiring issues.
-**If 50-80% pass:** Selectively fix the passing-adjacent tests, delete the rest.
-**If <50% pass:** Close the Phase 2 issues. The tests need rewriting, not patching. File a separate issue for writing proper tests from scratch.
-
----
-
-## Phase 2: Test-Code Contract Mismatch Fixes (GATED — pending Phase 1 results)
-
-Issues created but not yet approved for implementation:
-- [#76](https://github.com/lbnl-science-it/WorkJournalMaker/issues/76) — WorkWeekConfig validation test contracts (11 failures)
-- [#77](https://github.com/lbnl-science-it/WorkJournalMaker/issues/77) — Work week settings service test contract (1 failure)
-- [#78](https://github.com/lbnl-science-it/WorkJournalMaker/issues/78) — Build config test contracts (2 failures)
-- [#79](https://github.com/lbnl-science-it/WorkJournalMaker/issues/79) — Settings persistence test setup (6 failures)
-- [#80](https://github.com/lbnl-science-it/WorkJournalMaker/issues/80) — Full scope verification
-
-See full prompts and details for these steps in the
-[spec](implementation_plans/fix_issue_60_spec.md) and the GitHub issues above.
-These will be revisited after the decision gate.
+**Decision: Do not proceed with Phase 2.** Issues #76-80 closed.
+Filed [#81](https://github.com/lbnl-science-it/WorkJournalMaker/issues/81) to write proper test coverage from scratch.

--- a/plan.md
+++ b/plan.md
@@ -1,373 +1,157 @@
-# Cluster F: CLI Cleanup — Implementation Plan
+# Fix Pre-existing Test Failures — Issue #60 Plan
 
-**Source:** `improvements.md` items #4, #5, #11, #18
-**Branch:** `improvements/cluster-f-cli-cleanup`
-**Depends on:** Cluster A only (independent of B-E chain)
-
----
-
-## Overview
-
-Four cleanup items targeting CLI pipeline code:
-
-| Step | Item | File | Risk | Scope |
-|------|------|------|------|-------|
-| 1 | #18 | `file_discovery.py` | Low | Remove ~225 lines of dead migration scaffolding |
-| 2 | #11 | `file_discovery.py` | Low | Remove mock-detection logic from production code |
-| 3 | #4 | `work_journal_summarizer.py` | Low | Fix hardcoded provider output |
-| 4 | #5 | `work_journal_summarizer.py` | Medium | Decompose 519-line `main()` into phase functions |
-
-**Ordering rationale:** Start with the safest, most mechanical deletions (#18, #11)
-in `file_discovery.py`, then fix the small provider output bug (#4), and finish
-with the largest refactor (#5). Steps 1-2 touch `file_discovery.py`; steps 3-4
-touch `work_journal_summarizer.py`. No cross-file dependencies between steps.
+**Issue:** [#60](https://github.com/lbnl-science-it/WorkJournalMaker/issues/60)
+**Branch:** `fix/issue-60-test-failures`
+**Baseline:** 54 failed + 18 errors = 72 broken tests across 11 files (in scope)
+**Full suite baseline:** 169 failed, 1349 passed, 27 errors
 
 ---
 
-## Step 1: Remove Migration Scaffolding from file_discovery.py
+## Phase 1: Async Fixture Decorator Fixes
 
-**Item:** #18 from improvements.md
-**Risk:** Low — methods are not called by any production code.
+**Goal:** Fix the 37 failures + 18 errors caused by `@pytest.fixture` on `async def` functions.
+**Risk:** Low — mechanical decorator swaps.
+**Scope:** 7 test files, ~26 async fixtures to swap.
 
-### What to change
+### Step 1.1: Fix work_week async test fixtures — [#73](https://github.com/lbnl-science-it/WorkJournalMaker/issues/73)
 
-Remove these three methods from `FileDiscovery`:
-- `compare_discovery_results()` (lines 781-867, ~87 lines)
-- `validate_migration_success_criteria()` (lines 869-956, ~88 lines)
-- `_log_migration_validation()` (lines 958-1007, ~50 lines)
-
-Total: ~225 lines of dead code.
-
-### Tests to update
-
-Remove the corresponding tests from `tests/test_file_discovery_v2_core_functionality.py`:
-- `test_compare_discovery_results_identical` (line 151)
-- `test_compare_discovery_results_different` (line 163)
-- `test_compare_discovery_results_with_detailed_analysis` (line 188)
-- `test_validate_migration_success_criteria` (line 215)
-- `test_validate_migration_failure_criteria` (line 243)
-- `_create_mock_result` helper (line 270, only used by the above tests)
-
-### Verification
-
-1. Run full file_discovery test suite — all tests pass
-2. Grep codebase for removed method names — zero hits outside improvements.md
-
-### Prompt
+**Files:** `tests/test_work_week_compatibility.py`, `tests/test_work_week_database_sync.py`, `tests/test_work_week_integration.py`, `tests/test_work_week_performance.py`
+**What:** Replace `@pytest.fixture` with `@pytest_asyncio.fixture` on all async fixtures. Add `import pytest_asyncio` where missing.
+**Verification:** Run these 4 files — failures should drop significantly.
 
 ```text
-Remove the migration scaffolding methods from file_discovery.py. These methods
-are not called by any production code and exist only as one-time migration
-validation tools that have served their purpose.
+Fix async fixture decorators in the work week test files for issue #60.
 
-Remove these methods from the FileDiscovery class:
-- compare_discovery_results() (lines 781-867)
-- validate_migration_success_criteria() (lines 869-956)
-- _log_migration_validation() (lines 958-1007)
+In pytest-asyncio strict mode, async fixtures must use @pytest_asyncio.fixture
+instead of @pytest.fixture, otherwise sync test functions receive coroutine
+objects instead of resolved values.
 
-Also remove the corresponding tests from
-tests/test_file_discovery_v2_core_functionality.py:
-- test_compare_discovery_results_identical
-- test_compare_discovery_results_different
-- test_compare_discovery_results_with_detailed_analysis
-- test_validate_migration_success_criteria
-- test_validate_migration_failure_criteria
-- _create_mock_result helper (only used by the above tests)
+Files to fix:
+1. tests/test_work_week_compatibility.py — 2 async fixtures need decorator swap, add import pytest_asyncio
+2. tests/test_work_week_database_sync.py — 5 async fixtures need decorator swap, add import pytest_asyncio
+3. tests/test_work_week_integration.py — check for async fixtures, add import pytest_asyncio if needed
+4. tests/test_work_week_performance.py — 2 async fixtures need decorator swap (pytest_asyncio already imported)
 
-After removal, run the full file_discovery test suite to confirm no regressions:
-  pytest tests/test_file_discovery*.py -v
+For each file:
+1. Find all fixtures defined with `@pytest.fixture` and `async def`
+2. Replace `@pytest.fixture` with `@pytest_asyncio.fixture` on those fixtures
+3. Add `import pytest_asyncio` at the top if not already present
+4. Do NOT change any test logic, assertions, or non-fixture code
 
-Verify with grep that no production code references the removed methods.
+After fixes, run:
+  pytest tests/test_work_week_compatibility.py tests/test_work_week_database_sync.py \
+    tests/test_work_week_integration.py tests/test_work_week_performance.py --tb=short -q
+
+Commit: "Fix async fixture decorators in work week tests (#60, step 1.1)"
 ```
 
----
+### Step 1.2: Fix calendar async test fixtures — [#74](https://github.com/lbnl-science-it/WorkJournalMaker/issues/74)
 
-## Step 2: Remove Mock-Detection Logic from file_discovery.py
-
-**Item:** #11 from improvements.md
-**Risk:** Low — removing test infrastructure that leaked into production code.
-
-### What to change
-
-In `_construct_missing_file_path()` (lines 702-779), there are three blocks
-that check `hasattr(result, '_mock_name')` to detect mock objects:
-
-1. Lines 738-746: First match block
-2. Lines 756-764: Closest-match fallback block
-3. Lines 769-777: Final fallback block
-
-Each block follows this pattern:
-```python
-result = directory_path / filename
-if hasattr(result, 'name') and not hasattr(result, '_mock_name'):
-    return result
-else:
-    return Path(str(directory_path)) / filename
-```
-
-Replace each with simply:
-```python
-return directory_path / filename
-```
-
-The `try/except (TypeError, AttributeError)` around each can also be removed
-since `directory_path` is always a `Path` object from the directory scanner.
-
-### TDD approach
-
-1. Write a test for `_construct_missing_file_path` using real `Path` objects
-   (not mocks) that validates the method returns correct paths
-2. Confirm test passes with current code
-3. Simplify the method by removing mock-detection
-4. Confirm test still passes
-
-### Verification
-
-1. Run full file_discovery test suite
-2. Grep for `_mock_name` in production code — zero hits
-
-### Prompt
+**Files:** `tests/test_calendar_interface_step14.py`, `tests/test_calendar_service_integration.py`
+**What:** Same decorator swap pattern. These files also have setup/teardown errors (Category 3) that should resolve.
+**Verification:** Run these 2 files — expect errors to resolve.
 
 ```text
-Remove mock-detection logic from _construct_missing_file_path() in
-file_discovery.py. The method currently has hasattr(result, '_mock_name')
-checks at three locations — this is test infrastructure that leaked into
-production code.
+Fix async fixture decorators in the calendar test files for issue #60.
 
-TDD approach:
-1. First, write a test in tests/test_file_discovery_v2_file_extraction.py
-   that tests _construct_missing_file_path with real Path objects:
-   - Test with a matching week directory (week_start <= date <= week_ending)
-   - Test with a closest-match fallback directory
-   - Test with only one directory available (final fallback)
-   - Test with empty directories list (returns None)
+Same root cause as step 1.1: async fixtures using @pytest.fixture instead of
+@pytest_asyncio.fixture in strict mode.
 
-2. Run the test to confirm it passes with the current code.
+Files to fix:
+1. tests/test_calendar_interface_step14.py — 5 async fixtures need decorator swap, add import pytest_asyncio
+2. tests/test_calendar_service_integration.py — 7 async fixtures need decorator swap, add import pytest_asyncio
 
-3. Simplify _construct_missing_file_path by replacing each of the three
-   mock-detection blocks:
+For each file:
+1. Find all fixtures defined with `@pytest.fixture` and `async def`
+2. Replace `@pytest.fixture` with `@pytest_asyncio.fixture` on those fixtures
+3. Add `import pytest_asyncio` at the top if not already present
+4. Do NOT change any test logic, assertions, or non-fixture code
 
-   BEFORE (repeated 3 times with slight variations):
-   ```python
-   try:
-       result = directory_path / filename
-       if hasattr(result, 'name') and not hasattr(result, '_mock_name'):
-           return result
-       else:
-           return Path(str(directory_path)) / filename
-   except (TypeError, AttributeError):
-       return Path(str(directory_path)) / filename
-   ```
+After fixes, run:
+  pytest tests/test_calendar_interface_step14.py tests/test_calendar_service_integration.py --tb=short -q
 
-   AFTER:
-   ```python
-   return directory_path / filename
-   ```
-
-4. Run the test again to confirm it still passes.
-5. Run the full file_discovery test suite: pytest tests/test_file_discovery*.py -v
-6. Grep for _mock_name in all non-test .py files to verify zero hits.
+Commit: "Fix async fixture decorators in calendar tests (#60, step 1.2)"
 ```
 
----
+### Step 1.3: Fix web integration async test fixtures — [#75](https://github.com/lbnl-science-it/WorkJournalMaker/issues/75)
 
-## Step 3: Fix Provider-Specific Output in work_journal_summarizer.py
-
-**Item:** #4 from improvements.md
-**Risk:** Low — two lines of print output.
-
-### What to change
-
-Lines 514-515 in `main()`:
-```python
-print(f"AWS Region: {config.bedrock.region}")
-print(f"Model: {config.bedrock.model_id}")
-```
-
-Replace with provider-agnostic output using the same pattern already used in
-`_perform_dry_run()` (lines 370-374):
-```python
-llm_client = UnifiedLLMClient(config, on_fallback=fallback_notification)
-provider_info = llm_client.get_provider_info()
-for key, value in provider_info.items():
-    if key not in ("fallback_providers",):
-        print(f"{key.replace('_', ' ').title()}: {value}")
-```
-
-### TDD approach
-
-1. Create `tests/test_work_journal_summarizer.py`
-2. Write a test that verifies provider-agnostic output: mock the
-   `UnifiedLLMClient` to return google_genai provider info and confirm
-   stdout does NOT contain "AWS Region"
-3. Implement the fix
-4. Confirm tests pass
-
-### Verification
-
-1. Run the new tests
-2. Grep for "AWS Region" in work_journal_summarizer.py — zero hits
-
-### Prompt
+**Files:** `tests/test_web_integration.py`
+**What:** Same decorator swap pattern. 5 async fixtures + setup/teardown errors.
+**Verification:** Run this file — expect errors to resolve.
 
 ```text
-Fix the hardcoded provider output in work_journal_summarizer.py. Lines 514-515
-always print AWS Region and Bedrock Model regardless of which LLM provider is
-active. When using google_genai, this displays misleading information.
+Fix async fixture decorators in the web integration test file for issue #60.
 
-TDD approach:
-1. Create tests/test_work_journal_summarizer.py with tests that verify
-   provider-agnostic output:
-   - Test that with a google_genai config, the banner does NOT print
-     "AWS Region" or "Model: anthropic..."
-   - Test that the banner prints provider info from get_provider_info()
-   You will need to mock UnifiedLLMClient and config appropriately since
-   we cannot make real API calls in unit tests. Focus on testing that the
-   correct provider_info keys are printed, not the LLM behavior itself.
+Same root cause as steps 1.1 and 1.2.
 
-2. Run the test — it should fail because current code hardcodes Bedrock output.
+File to fix:
+1. tests/test_web_integration.py — 5 async fixtures need decorator swap, add import pytest_asyncio
 
-3. Replace lines 514-515 with provider-agnostic output. The dry_run path
-   (_perform_dry_run, lines 370-374) already does this correctly — follow
-   that pattern:
-   ```python
-   llm_client = UnifiedLLMClient(config, on_fallback=fallback_notification)
-   provider_info = llm_client.get_provider_info()
-   for key, value in provider_info.items():
-       if key not in ("fallback_providers",):
-           print(f"{key.replace('_', ' ').title()}: {value}")
-   ```
+Steps:
+1. Find all fixtures defined with `@pytest.fixture` and `async def`
+2. Replace `@pytest.fixture` with `@pytest_asyncio.fixture` on those fixtures
+3. Add `import pytest_asyncio` at the top if not already present
+4. Do NOT change any test logic, assertions, or non-fixture code
 
-4. Run the test — it should pass.
-5. Run the full test suite to check for regressions.
+After fixes, run:
+  pytest tests/test_web_integration.py --tb=short -q
+
+Commit: "Fix async fixture decorators in web integration tests (#60, step 1.3)"
 ```
 
----
+### Step 1.4: Phase 1 verification and decision gate
 
-## Step 4: Decompose main() into Phase Functions
-
-**Item:** #5 from improvements.md
-**Risk:** Medium — largest change; must preserve exact phase ordering and error handling.
-
-### Analysis of current main()
-
-The 519-line `main()` (lines 425-943) contains these logical phases:
-
-| Phase | Lines | Description |
-|-------|-------|-------------|
-| Args & Config | 442-516 | Parse args, init config, init logger, display banner |
-| File Discovery | 521-596 | Discover journal files |
-| Content Processing | 597-651 | Process file content |
-| LLM Analysis | 653-738 | Analyze content with LLM API |
-| Summary Generation | 743-821 | Generate intelligent summaries |
-| Output Management | 824-874 | Create markdown output |
-| Quality Metrics | 911-928 | Display content quality stats |
-| Error Handling | 929-943 | No-files-found + KeyboardInterrupt + catch-all |
-
-### Decomposition strategy
-
-Extract each phase into a standalone function. Each function:
-- Takes explicit parameters (no globals)
-- Returns its results as a value
-- Raises on unrecoverable failure
-- Handles its own try/except for recoverable errors
-
-`main()` becomes a thin orchestrator that calls each phase function in sequence.
-
-### Incremental approach (4 sub-steps)
-
-Because this is a large refactor, we break it into sub-steps that each leave
-the code in a working state:
-
-#### 4a: Extract file discovery phase
-Extract lines 521-596 into `_run_file_discovery()`.
-
-#### 4b: Extract content processing and LLM analysis phases
-Extract lines 597-738 into `_run_content_processing()` and `_run_llm_analysis()`.
-
-#### 4c: Extract summary generation and output phases
-Extract lines 743-874 into `_run_summary_generation()` and `_run_output_generation()`.
-
-#### 4d: Extract initialization and cleanup
-Extract the banner display and quality metrics into helper functions.
-Clean up `main()` to be a pure orchestrator.
-
-### TDD approach
-
-Build on the test file created in Step 3. For each sub-step:
-
-1. Write a test for the extracted function in isolation
-2. Extract the function
-3. Verify the test passes
-4. Run the full test suite to verify no regressions
-
-### Prompt
+**What:** Run all 7 files together. Record results. Decide whether Phase 2 is worth pursuing.
 
 ```text
-Decompose the 519-line main() function in work_journal_summarizer.py into
-focused phase functions. The goal is for main() to become a thin orchestrator
-that calls each phase in sequence.
+Run the full Phase 1 verification for issue #60.
 
-This is a large refactor. Do it incrementally in 4 sub-steps, running tests
-after each sub-step.
+Run all 7 async-fixture-affected files together:
+  pytest tests/test_work_week_compatibility.py tests/test_work_week_database_sync.py \
+    tests/test_work_week_integration.py tests/test_work_week_performance.py \
+    tests/test_calendar_interface_step14.py tests/test_calendar_service_integration.py \
+    tests/test_web_integration.py --tb=short -q
 
-IMPORTANT: Preserve exact behavior. Do not change logic, error messages, print
-output, or error handling semantics. This is a pure structural refactor.
+Baseline was: 37 failed + 18 errors = 55 broken tests.
+Expected: Most or all should now pass.
 
-Sub-step 4a — Extract file discovery:
-  Extract the file discovery phase into a function:
-    def _run_file_discovery(config, args, logger) -> FileDiscoveryResult
-  - Takes config, args, logger as parameters
-  - Returns FileDiscoveryResult
-  - Handles its own try/except, returns empty result on failure
-  - Write a test that verifies it returns a FileDiscoveryResult
+Record the results. This is a DECISION GATE:
+- If most tests pass: the test authors got the logic right, just the decorators
+  wrong. Phase 2 contract fixes are likely worth doing.
+- If most tests STILL FAIL with new errors: the tests were poorly written
+  end-to-end. Phase 2 should be reconsidered — deleting and rewriting may be
+  more appropriate than patching.
 
-Sub-step 4b — Extract content processing and LLM analysis:
-  Extract into:
-    def _run_content_processing(found_files, config) -> Tuple[List[ProcessedContent], ProcessingStats]
-  Extract into:
-    def _run_llm_analysis(processed_content, config) -> Tuple[List[AnalysisResult], APIStats, dict]
-  - The dict return from _run_llm_analysis contains the aggregated entity sets
-  - Write tests for each function
+Do NOT change production code. Only fix test wiring issues.
 
-Sub-step 4c — Extract summary and output:
-  Extract into:
-    def _run_summary_generation(analysis_results, llm_client, args) -> Tuple[List[PeriodSummary], SummaryStats]
-  Extract into:
-    def _run_output_generation(summaries, args, discovery_result, processing_stats, api_stats, summary_stats, entity_sets, config) -> OutputResult
-  - Write tests for each function
-
-Sub-step 4d — Clean up main():
-  Extract the banner display into:
-    def _display_banner(args, config, provider_info)
-  Extract quality metrics into:
-    def _display_quality_metrics(processed_content)
-  Clean up main() to be a linear orchestrator:
-    1. Parse args & init config/logger
-    2. Handle special modes (save-example-config, dry-run)
-    3. _display_banner()
-    4. _run_file_discovery()
-    5. _run_content_processing()
-    6. _run_llm_analysis()
-    7. _run_summary_generation()
-    8. _run_output_generation()
-    9. _display_quality_metrics()
-
-After all sub-steps, main() should be ~50-80 lines of orchestration code.
-Run the full test suite after each sub-step.
+Commit: "Verify Phase 1 async fixture fixes (#60, step 1.4)" (if any additional fixes needed)
 ```
 
 ---
 
-## Verification Checklist
+## Decision Gate: Evaluate Phase 2
 
-After all 4 steps:
+**After Phase 1 completes, answer these questions:**
 
-- [ ] `pytest tests/test_file_discovery*.py -v` — all pass
-- [ ] `pytest tests/test_work_journal_summarizer.py -v` — all pass
-- [ ] `pytest -v` — full suite passes
-- [ ] `grep -r '_mock_name' *.py` — zero hits in production code
-- [ ] `grep -r 'compare_discovery_results\|validate_migration_success' *.py` — zero hits outside improvements.md
-- [ ] `grep -r 'AWS Region' work_journal_summarizer.py` — zero hits
-- [ ] `main()` is ≤80 lines
-- [ ] No behavioral changes to CLI output (except provider-specific lines)
+1. How many of the 55 broken tests now pass?
+2. Of those that still fail, are the failures shallow (assertion tweaks) or deep (fundamentally wrong test design)?
+3. Is the signal-to-noise improvement from Phase 1 alone sufficient?
+
+**If >80% pass:** Proceed with Phase 2 — the tests have value, just wiring issues.
+**If 50-80% pass:** Selectively fix the passing-adjacent tests, delete the rest.
+**If <50% pass:** Close the Phase 2 issues. The tests need rewriting, not patching. File a separate issue for writing proper tests from scratch.
+
+---
+
+## Phase 2: Test-Code Contract Mismatch Fixes (GATED — pending Phase 1 results)
+
+Issues created but not yet approved for implementation:
+- [#76](https://github.com/lbnl-science-it/WorkJournalMaker/issues/76) — WorkWeekConfig validation test contracts (11 failures)
+- [#77](https://github.com/lbnl-science-it/WorkJournalMaker/issues/77) — Work week settings service test contract (1 failure)
+- [#78](https://github.com/lbnl-science-it/WorkJournalMaker/issues/78) — Build config test contracts (2 failures)
+- [#79](https://github.com/lbnl-science-it/WorkJournalMaker/issues/79) — Settings persistence test setup (6 failures)
+- [#80](https://github.com/lbnl-science-it/WorkJournalMaker/issues/80) — Full scope verification
+
+See full prompts and details for these steps in the
+[spec](implementation_plans/fix_issue_60_spec.md) and the GitHub issues above.
+These will be revisited after the decision gate.

--- a/tests/test_work_week_compatibility.py
+++ b/tests/test_work_week_compatibility.py
@@ -7,6 +7,7 @@ maintains backward compatibility with existing installations and data.
 
 import asyncio
 import pytest
+import pytest_asyncio
 import tempfile
 import shutil
 import os
@@ -26,7 +27,7 @@ from logger import JournalSummarizerLogger
 class TestWorkWeekBackwardCompatibility:
     """Test class for work week backward compatibility validation."""
     
-    @pytest.fixture
+    @pytest_asyncio.fixture
     async def legacy_setup(self):
         """Set up a legacy-style directory structure for testing."""
         temp_dir = tempfile.mkdtemp()
@@ -63,7 +64,7 @@ class TestWorkWeekBackwardCompatibility:
         # Cleanup
         shutil.rmtree(temp_dir)
     
-    @pytest.fixture
+    @pytest_asyncio.fixture
     async def database_with_legacy_data(self):
         """Set up database with legacy journal entry data."""
         db_manager = DatabaseManager(":memory:")

--- a/tests/test_work_week_database_sync.py
+++ b/tests/test_work_week_database_sync.py
@@ -6,6 +6,7 @@ including entry synchronization, migration, and data integrity validation.
 """
 
 import pytest
+import pytest_asyncio
 import asyncio
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -20,7 +21,7 @@ from logger import JournalSummarizerLogger
 
 
 # Test fixtures - defined at module level
-@pytest.fixture
+@pytest_asyncio.fixture
 async def temp_database():
     """Create temporary database for testing."""
     with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as tmp:
@@ -51,12 +52,12 @@ def mock_logger():
     logger.error = Mock()
     return logger
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def work_week_service(mock_config, mock_logger, temp_database):
     """Create WorkWeekService instance."""
     return WorkWeekService(mock_config, mock_logger, temp_database)
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def entry_manager(mock_config, mock_logger, temp_database, work_week_service):
     """Create EntryManager instance with WorkWeekService."""
     return EntryManager(mock_config, mock_logger, temp_database, work_week_service)

--- a/todo.md
+++ b/todo.md
@@ -1,12 +1,28 @@
-# Cluster F: CLI Cleanup — Implementation Tracker
+# Issue #60 — Fix Pre-existing Test Failures
 
 **Plan:** `plan.md`
-**Source:** `improvements.md` items #4, #5, #11, #18
-**Branch:** `improvements/cluster-f-cli-cleanup`
+**Branch:** `fix/issue-60-test-failures`
+**Baseline:** 54 failed + 18 errors = 72 broken (in scope) | 169 failed full suite
 
-## Steps
+## Phase 1: Async Fixture Decorator Fixes (APPROVED)
 
-- [x] **Step 1:** Remove migration scaffolding from file_discovery.py ([#65](https://github.com/lbnl-science-it/WorkJournalMaker/issues/65))
-- [x] **Step 2:** Remove mock-detection logic from file_discovery.py ([#66](https://github.com/lbnl-science-it/WorkJournalMaker/issues/66))
-- [x] **Step 3:** Fix hardcoded provider output in work_journal_summarizer.py ([#67](https://github.com/lbnl-science-it/WorkJournalMaker/issues/67))
-- [x] **Step 4:** Decompose main() into phase functions ([#68](https://github.com/lbnl-science-it/WorkJournalMaker/issues/68))
+- [ ] **Step 1.1:** Fix work_week async test fixtures ([#73](https://github.com/lbnl-science-it/WorkJournalMaker/issues/73))
+- [ ] **Step 1.2:** Fix calendar async test fixtures ([#74](https://github.com/lbnl-science-it/WorkJournalMaker/issues/74))
+- [ ] **Step 1.3:** Fix web integration async test fixtures ([#75](https://github.com/lbnl-science-it/WorkJournalMaker/issues/75))
+- [ ] **Step 1.4:** Phase 1 verification + decision gate
+
+## Decision Gate
+
+After Phase 1, evaluate results:
+- **>80% pass** → proceed with Phase 2
+- **50-80% pass** → selectively fix, delete the rest
+- **<50% pass** → close Phase 2 issues, rewrite from scratch
+
+## Phase 2: Contract Mismatch Fixes (GATED — pending Phase 1 results)
+
+- [ ] **Step 2.1:** WorkWeekConfig validation test contracts ([#76](https://github.com/lbnl-science-it/WorkJournalMaker/issues/76)) — 11 failures
+- [ ] **Step 2.2:** Work week settings service test contract ([#77](https://github.com/lbnl-science-it/WorkJournalMaker/issues/77)) — 1 failure
+- [ ] **Step 2.3:** Build config test contracts ([#78](https://github.com/lbnl-science-it/WorkJournalMaker/issues/78)) — 2 failures
+- [ ] **Step 2.4:** Settings persistence test setup ([#79](https://github.com/lbnl-science-it/WorkJournalMaker/issues/79)) — 6 failures
+- [ ] **Step 3.1:** Full scope verification ([#80](https://github.com/lbnl-science-it/WorkJournalMaker/issues/80))
+- [ ] **Step 3.2:** Update and close issue #60

--- a/todo.md
+++ b/todo.md
@@ -1,28 +1,22 @@
-# Issue #60 — Fix Pre-existing Test Failures
+# Issue #60 — Fix Pre-existing Test Failures (CLOSED)
 
 **Plan:** `plan.md`
 **Branch:** `fix/issue-60-test-failures`
-**Baseline:** 54 failed + 18 errors = 72 broken (in scope) | 169 failed full suite
+**Result:** 6 tests recovered, Phase 2 cancelled, rewrite filed as #81
 
-## Phase 1: Async Fixture Decorator Fixes (APPROVED)
+## Phase 1: Async Fixture Decorator Fixes (COMPLETE)
 
-- [ ] **Step 1.1:** Fix work_week async test fixtures ([#73](https://github.com/lbnl-science-it/WorkJournalMaker/issues/73))
-- [ ] **Step 1.2:** Fix calendar async test fixtures ([#74](https://github.com/lbnl-science-it/WorkJournalMaker/issues/74))
-- [ ] **Step 1.3:** Fix web integration async test fixtures ([#75](https://github.com/lbnl-science-it/WorkJournalMaker/issues/75))
-- [ ] **Step 1.4:** Phase 1 verification + decision gate
+- [x] **Step 1.1:** Fix work_week async test fixtures ([#73](https://github.com/lbnl-science-it/WorkJournalMaker/issues/73)) — 6 tests recovered
+- [x] **Step 1.2:** Calendar tests — no async fixture issues found ([#74](https://github.com/lbnl-science-it/WorkJournalMaker/issues/74))
+- [x] **Step 1.3:** Web tests — no async fixture issues found ([#75](https://github.com/lbnl-science-it/WorkJournalMaker/issues/75))
+- [x] **Step 1.4:** Decision gate — 11% recovery, below 50% threshold
 
-## Decision Gate
+## Decision Gate Result: DO NOT PROCEED
 
-After Phase 1, evaluate results:
-- **>80% pass** → proceed with Phase 2
-- **50-80% pass** → selectively fix, delete the rest
-- **<50% pass** → close Phase 2 issues, rewrite from scratch
+- Recovery rate: 11% (6 of 55 broken tests)
+- Root cause: tests were never validated against production code
+- Action: Phase 2 closed, rewrite issue filed
 
-## Phase 2: Contract Mismatch Fixes (GATED — pending Phase 1 results)
+## Phase 2: CANCELLED
 
-- [ ] **Step 2.1:** WorkWeekConfig validation test contracts ([#76](https://github.com/lbnl-science-it/WorkJournalMaker/issues/76)) — 11 failures
-- [ ] **Step 2.2:** Work week settings service test contract ([#77](https://github.com/lbnl-science-it/WorkJournalMaker/issues/77)) — 1 failure
-- [ ] **Step 2.3:** Build config test contracts ([#78](https://github.com/lbnl-science-it/WorkJournalMaker/issues/78)) — 2 failures
-- [ ] **Step 2.4:** Settings persistence test setup ([#79](https://github.com/lbnl-science-it/WorkJournalMaker/issues/79)) — 6 failures
-- [ ] **Step 3.1:** Full scope verification ([#80](https://github.com/lbnl-science-it/WorkJournalMaker/issues/80))
-- [ ] **Step 3.2:** Update and close issue #60
+- [x] ~~#76, #77, #78, #79, #80~~ — closed, superseded by [#81](https://github.com/lbnl-science-it/WorkJournalMaker/issues/81)


### PR DESCRIPTION
## Summary

- Fixed 5 async fixture decorators in `test_work_week_compatibility.py` and `test_work_week_database_sync.py` (`@pytest.fixture` → `@pytest_asyncio.fixture`)
- Recovered 6 previously broken tests
- Evaluated remaining 49 broken tests via decision gate — determined they need rewriting, not patching
- Closed Phase 2 issues #76-80, filed #81 for proper test coverage rewrite

## Decision Gate Results

| Metric | Before | After |
|--------|--------|-------|
| Passed (7-file scope) | 22 | 28 |
| Broken (7-file scope) | 55 | 49 |
| Recovery rate | — | 11% |

11% is below the 50% threshold. The remaining failures stem from stale API contracts, removed model columns, and fixture scoping bugs — tests that were never run successfully.

## Test plan

- [x] `pytest tests/test_work_week_compatibility.py tests/test_work_week_database_sync.py --tb=short -q` — 6 additional tests now pass
- [x] No regressions in previously passing tests

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)