### PR TITLE
Add database isolation to isolated_app_client fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,29 @@
 # ABOUTME: Shared pytest fixtures for the web API test suite.
-# ABOUTME: Provides isolated_app_client that redirects all file writes to tmp_path.
+# ABOUTME: Provides isolated_app_client that redirects file and DB writes to tmp_path.
 
+import asyncio
 import pytest
 from datetime import datetime, timedelta, timezone
 
 from fastapi.testclient import TestClient
 
 from web.app import app
+from web.database import DatabaseManager
 from file_discovery import FileDiscovery
 
 
 @pytest.fixture
 def isolated_app_client(tmp_path):
     """
-    A TestClient that redirects all entry_manager file writes to tmp_path.
+    A TestClient that redirects all entry_manager file writes to tmp_path
+    and all database writes to a temporary SQLite database.
 
-    Patches app.state.entry_manager after the app lifespan startup so that
-    FileDiscovery writes to tmp_path instead of ~/Desktop/worklogs/.
-    The settings cache is pinned to prevent re-initialization from DB or config.
+    Patches app.state services after the app lifespan startup so that:
+    1. FileDiscovery writes to tmp_path instead of ~/Desktop/worklogs/
+    2. All services use a temp database instead of web/journal_index.db
 
-    WARNING: This fixture mutates a module-level singleton (app.state.entry_manager)
-    and restores it on teardown. It is not compatible with pytest-xdist parallel
+    WARNING: This fixture mutates module-level singletons (app.state services)
+    and restores them on teardown. It is not compatible with pytest-xdist parallel
     execution, which runs tests in separate workers sharing the same process state.
     """
     with TestClient(app) as client:
@@ -43,10 +46,36 @@ def isolated_app_client(tmp_path):
         }
         em._settings_cache_expiry = datetime.now(timezone.utc) + timedelta(hours=1)
 
+        # --- Database isolation ---
+        temp_db = DatabaseManager(str(tmp_path / "test_journal_index.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(temp_db.initialize())
+
+        # Swap db_manager on every service that holds one (introspection-based
+        # so new services are picked up automatically).
+        orig_db_managers = {}
+        for name, svc in app.state._state.items():
+            if name != 'db_manager' and hasattr(svc, 'db_manager'):
+                orig_db_managers[name] = svc.db_manager
+                svc.db_manager = temp_db
+
+        orig_app_db = app.state.db_manager
+        app.state.db_manager = temp_db
+
         yield client
 
-        # Restore originals so the module-level singleton isn't permanently mutated
+        # Restore originals so the module-level singletons aren't permanently mutated
         em.file_discovery = orig_file_discovery
         em._current_base_path = orig_base_path
         em._settings_cache = orig_settings_cache
         em._settings_cache_expiry = orig_settings_cache_expiry
+
+        for name in orig_db_managers:
+            svc = getattr(app.state, name, None)
+            if svc is not None:
+                svc.db_manager = orig_db_managers[name]
+        app.state.db_manager = orig_app_db
+
+        if temp_db.engine:
+            loop.run_until_complete(temp_db.engine.dispose())
+        loop.close()

--- a/tests/test_isolation_sentinel.py
+++ b/tests/test_isolation_sentinel.py
@@ -1,14 +1,16 @@
-# ABOUTME: Sentinel test verifying that test isolation redirects file writes to tmp_path.
-# ABOUTME: Guards against test suites accidentally writing to real worklog files.
+# ABOUTME: Sentinel test verifying that test isolation redirects file and DB writes.
+# ABOUTME: Guards against test suites accidentally mutating real worklog files or database.
 
 """
 Sentinel Test for Test Isolation
 
 Verifies that the isolated_app_client fixture correctly redirects
-all file write operations to tmp_path instead of ~/Desktop/worklogs/.
+all file write operations to tmp_path instead of ~/Desktop/worklogs/,
+and all database writes to a temp database instead of web/journal_index.db.
 """
 
 import pytest
+import sqlite3
 from pathlib import Path
 from datetime import date
 
@@ -128,3 +130,42 @@ class TestIsolationSentinel:
         assert len(written_files) > 0
         content = written_files[0].read_text()
         assert "Updated sentinel content" in content
+
+
+class TestDatabaseIsolationSentinel:
+    """Verify that isolated_app_client writes settings to a temp DB, not the real one."""
+
+    def test_settings_write_does_not_mutate_real_db(self, isolated_app_client, tmp_path):
+        """PUT /api/settings/ui.theme must NOT modify web/journal_index.db."""
+        from web.database import db_manager as real_db_manager
+        real_db_path = real_db_manager.database_path
+
+        # Snapshot the real DB's ui.theme value before the test
+        conn = sqlite3.connect(real_db_path)
+        row = conn.execute(
+            "SELECT value FROM web_settings WHERE key = 'ui.theme'"
+        ).fetchone()
+        original_theme = row[0] if row else None
+        conn.close()
+
+        # Pick a theme value that differs from the current one
+        opposite_theme = "dark" if original_theme == "light" else "light"
+        response = isolated_app_client.put(
+            "/api/settings/ui.theme",
+            json={"value": opposite_theme}
+        )
+        assert response.status_code == 200
+
+        # Verify the real DB was NOT mutated
+        conn = sqlite3.connect(real_db_path)
+        row = conn.execute(
+            "SELECT value FROM web_settings WHERE key = 'ui.theme'"
+        ).fetchone()
+        current_theme = row[0] if row else None
+        conn.close()
+
+        assert current_theme == original_theme, (
+            f"Real database was mutated! ui.theme changed from "
+            f"'{original_theme}' to '{current_theme}'. "
+            "isolated_app_client must redirect DB writes to a temp database."
+        )


### PR DESCRIPTION
## Summary

- Restores DB isolation to `isolated_app_client` that was removed in PR #115, using introspection-based service discovery instead of a hardcoded service list
- Adds a sentinel test that verifies `PUT /api/settings/ui.theme` does not mutate the real `web/journal_index.db`
- Exposes a pre-existing false positive in `test_calendar_api_date_range` (tracked in #118)

## Problem

Integration tests using `isolated_app_client` go through the real FastAPI app stack. Without DB isolation, endpoints like `PUT /api/settings/ui.theme` and `POST /api/settings/bulk-update` write directly to the production database, risking data corruption (e.g., `filesystem.base_path` set to `/invalid/path/that/cannot/be/created`).

## Approach

The fixture creates a temp `DatabaseManager` and swaps it onto all services by introspecting `app.state._state` for any object with a `db_manager` attribute. This automatically covers new services without manual updates. On teardown, all originals are restored and the temp engine is disposed.

## Test plan

- [x] Sentinel test fails without the fix (RED), passes with it (GREEN)
- [x] All 5 sentinel tests pass (`tests/test_isolation_sentinel.py`)
- [x] All 48 settings tests pass (`test_settings_persistence.py`, `test_settings_di.py`)
- [x] 79/80 `isolated_app_client` tests pass; 1 pre-existing false positive exposed (#118)
- [x] `test_settings_service_shares_db_manager` identity check still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)