### PR TITLE
fix: harden DB migration with error handling and integrity check

### DIFF
--- a/tests/test_database_manager_paths.py
+++ b/tests/test_database_manager_paths.py
@@ -211,6 +211,41 @@ class TestDatabaseMigration(unittest.TestCase):
         marker = self._read_marker(self.old_db_path)
         self.assertEqual(marker, "old_data")
 
+    def test_copy_failure_cleans_up_temp_file_and_creates_fresh_db(self):
+        """When copy fails, temp file is removed and app creates a fresh DB."""
+        import asyncio
+
+        self._create_sqlite_db_with_marker(self.old_db_path, "old_data")
+
+        db_manager = DatabaseManager(database_path=str(self.new_db_path))
+        with patch('web.database.shutil.copy2', side_effect=OSError("disk full")):
+            asyncio.run(db_manager.initialize(old_db_path=str(self.old_db_path)))
+
+        # Fresh DB should exist (created by create_all), not the migrated one
+        self.assertTrue(self.new_db_path.exists())
+        # No leftover .tmp files in the target directory
+        tmp_files = list(self.new_db_path.parent.glob("*.tmp"))
+        self.assertEqual(tmp_files, [])
+
+    def test_corrupt_source_db_detected_and_removed(self):
+        """When source DB is corrupt, migrated copy is deleted and fresh DB created."""
+        import asyncio
+
+        # Write garbage that isn't valid SQLite
+        self.old_db_path.write_bytes(b"this is not a sqlite database at all")
+
+        db_manager = DatabaseManager(database_path=str(self.new_db_path))
+        asyncio.run(db_manager.initialize(old_db_path=str(self.old_db_path)))
+
+        # Fresh DB should exist (created by create_all)
+        self.assertTrue(self.new_db_path.exists())
+        # Verify the fresh DB is valid SQLite (not the garbage)
+        import sqlite3
+        conn = sqlite3.connect(str(self.new_db_path))
+        result = conn.execute("PRAGMA integrity_check").fetchone()
+        conn.close()
+        self.assertEqual(result[0], "ok")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/web/database.py
+++ b/web/database.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import shutil
+import sqlite3
 import tempfile
 from pathlib import Path
 from contextlib import asynccontextmanager
@@ -185,13 +186,39 @@ class DatabaseManager:
         if old_db_path and not db_file.exists():
             old_file = Path(old_db_path)
             if old_file.exists():
-                tmp_fd, tmp_path = tempfile.mkstemp(dir=db_file.parent, suffix=".tmp")
-                os.close(tmp_fd)
-                shutil.copy2(str(old_file), tmp_path)
-                os.replace(tmp_path, str(db_file))
-                logging.getLogger(__name__).info(
-                    "Migrated database from %s to %s", old_file, db_file
-                )
+                logger = logging.getLogger(__name__)
+                tmp_path = None
+                try:
+                    tmp_fd, tmp_path = tempfile.mkstemp(dir=db_file.parent, suffix=".tmp")
+                    os.close(tmp_fd)
+                    shutil.copy2(str(old_file), tmp_path)
+                    os.replace(tmp_path, str(db_file))
+                    tmp_path = None
+                except OSError as exc:
+                    logger.error(
+                        "Failed to migrate database from %s: %s", old_file, exc
+                    )
+                    if tmp_path and Path(tmp_path).exists():
+                        os.unlink(tmp_path)
+                else:
+                    # Validate the migrated file is a well-formed SQLite database
+                    try:
+                        conn = sqlite3.connect(str(db_file))
+                        result = conn.execute("PRAGMA integrity_check").fetchone()
+                        conn.close()
+                        if result[0] != "ok":
+                            raise sqlite3.DatabaseError(
+                                f"integrity_check returned: {result[0]}"
+                            )
+                        logger.info(
+                            "Migrated database from %s to %s", old_file, db_file
+                        )
+                    except (sqlite3.DatabaseError, sqlite3.OperationalError) as exc:
+                        logger.warning(
+                            "Migrated database failed integrity check, "
+                            "removing corrupt file: %s", exc
+                        )
+                        db_file.unlink(missing_ok=True)
 
         self.engine = create_async_engine(
             f"sqlite+aiosqlite:///{self.database_path}",


### PR DESCRIPTION
## Summary
- Wraps the atomic DB migration copy (`tempfile` + `os.replace`) in `try/except` to clean up temp files on failure (e.g., disk full, permission errors)
- Adds SQLite `PRAGMA integrity_check` validation after a successful migration copy — deletes corrupt files so the app falls through to `create_all` for a fresh DB
- Both failure paths are graceful: the app starts normally with a fresh database instead of crashing

## Test plan
- [x] `test_copy_failure_cleans_up_temp_file_and_creates_fresh_db` — verifies OSError during copy cleans up temp file and creates fresh DB
- [x] `test_corrupt_source_db_detected_and_removed` — verifies corrupt source DB is detected by integrity check, removed, and replaced with fresh DB
- [x] All 4 existing migration tests still pass (no regression)
- [x] All 39 database-related tests pass (`test_database_config.py` + `test_database_manager_paths.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)