### PR TITLE
docs: restructure todo.md into clustered triage plan

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,22 +1,66 @@
-# WorkJournalMaker — Outstanding Work
+# WorkJournalMaker — Issue Triage & Execution Plan
 
-## Open Bugs
+Full design: [docs/superpowers/specs/2026-05-08-issue-triage-design.md](docs/superpowers/specs/2026-05-08-issue-triage-design.md)
 
-- [x] [#84](https://github.com/lbnl-science-it/WorkJournalMaker/issues/84) — `WebSummarizationService` calls non-existent `SummaryGenerator` methods
-- [ ] [#67](https://github.com/lbnl-science-it/WorkJournalMaker/issues/67) — Fix hardcoded provider output in `work_journal_summarizer.py`
-- [ ] [#32](https://github.com/lbnl-science-it/WorkJournalMaker/issues/32) — Save button hidden when editor window is at the bottom
+## Cluster T1: Re-Audit & Fix Test Isolation
+
+- [x] Re-run isolation audit against current codebase (post-DB-relocation)
+- [ ] [#118](https://github.com/lbnl-science-it/WorkJournalMaker/issues/118) — Fix test_calendar_api_date_range: reads real production DB
+- [ ] [#116](https://github.com/lbnl-science-it/WorkJournalMaker/issues/116) — Clean up stale DB files after migration verification
+- [x] [#113](https://github.com/lbnl-science-it/WorkJournalMaker/issues/113) — Rewrite live-server tests to use TestClient with isolation
+- [x] Fix remaining DANGEROUS files identified by re-audit
+- [ ] **GATE:** No test writes to production data or leaves side effects
+
+## Cluster T2: Test Coverage Rewrite
+
+- [ ] [#81](https://github.com/lbnl-science-it/WorkJournalMaker/issues/81) — Rewrite test coverage for work week, calendar, and web integration services
+- [ ] **GATE:** Services have tests covering actual public APIs, properly isolated, passing
+
+## Cluster S: Security Hardening
+
+### Critical
+- [ ] [#87](https://github.com/lbnl-science-it/WorkJournalMaker/issues/87) — No authentication on any web API endpoint
+- [ ] [#88](https://github.com/lbnl-science-it/WorkJournalMaker/issues/88) — Multiple XSS vectors via innerHTML
+- [ ] [#89](https://github.com/lbnl-science-it/WorkJournalMaker/issues/89) — No CSRF protection on state-changing API calls
+
+### High
+- [ ] [#90](https://github.com/lbnl-science-it/WorkJournalMaker/issues/90) — Path traversal via validate-path endpoint
+- [ ] [#91](https://github.com/lbnl-science-it/WorkJournalMaker/issues/91) — No security response headers
+- [ ] [#92](https://github.com/lbnl-science-it/WorkJournalMaker/issues/92) — CDN script without Subresource Integrity
+- [ ] [#93](https://github.com/lbnl-science-it/WorkJournalMaker/issues/93) — Unescaped data in inline onclick attributes
+
+### Medium
+- [ ] [#94](https://github.com/lbnl-science-it/WorkJournalMaker/issues/94) — Prompt injection via unsanitized journal content
+- [ ] [#95](https://github.com/lbnl-science-it/WorkJournalMaker/issues/95) — Unrestricted base_path enables arbitrary file write
+- [ ] [#96](https://github.com/lbnl-science-it/WorkJournalMaker/issues/96) — Information disclosure via error messages
+- [ ] [#97](https://github.com/lbnl-science-it/WorkJournalMaker/issues/97) — CORS misconfiguration
+- [ ] [#98](https://github.com/lbnl-science-it/WorkJournalMaker/issues/98) — GCP project ID hardcoded in source code
+- [ ] [#99](https://github.com/lbnl-science-it/WorkJournalMaker/issues/99) — Client-only input validation
+- [ ] [#110](https://github.com/lbnl-science-it/WorkJournalMaker/issues/110) — Bulk update settings always returns HTTP 200
+
+### Low
+- [ ] [#100](https://github.com/lbnl-science-it/WorkJournalMaker/issues/100) — Full file_path exposed in API responses
+- [ ] [#101](https://github.com/lbnl-science-it/WorkJournalMaker/issues/101) — Full LLM request body logged at DEBUG level
+- [ ] [#102](https://github.com/lbnl-science-it/WorkJournalMaker/issues/102) — raw_response stores full error strings
+- [ ] [#103](https://github.com/lbnl-science-it/WorkJournalMaker/issues/103) — Timezone accepts arbitrary strings
+- [ ] [#104](https://github.com/lbnl-science-it/WorkJournalMaker/issues/104) — WebSocket endpoints without auth/origin check
+- [ ] [#105](https://github.com/lbnl-science-it/WorkJournalMaker/issues/105) — showToast passes error_message via innerHTML
+- [ ] [#106](https://github.com/lbnl-science-it/WorkJournalMaker/issues/106) — Test/debug pages accessible in production
+- [ ] [#107](https://github.com/lbnl-science-it/WorkJournalMaker/issues/107) — No content size limit on entry POST
+- [ ] [#108](https://github.com/lbnl-science-it/WorkJournalMaker/issues/108) — Scheduler accepts zero/negative intervals
+
+- [ ] **GATE:** Critical and high resolved; medium/low resolved or consciously accepted
+
+## Cluster U: UI Bugs
+
 - [ ] [#30](https://github.com/lbnl-science-it/WorkJournalMaker/issues/30) — Changing default work week fails
-- [ ] [#28](https://github.com/lbnl-science-it/WorkJournalMaker/issues/28) — Missized Calendar
-- [ ] [#27](https://github.com/lbnl-science-it/WorkJournalMaker/issues/27) — Calendar preview of journal entry cuts off
 - [ ] [#26](https://github.com/lbnl-science-it/WorkJournalMaker/issues/26) — Broken Today Button
+- [ ] [#27](https://github.com/lbnl-science-it/WorkJournalMaker/issues/27) — Calendar preview of journal entry cuts off
+- [ ] [#28](https://github.com/lbnl-science-it/WorkJournalMaker/issues/28) — Missized Calendar
+- [ ] [#32](https://github.com/lbnl-science-it/WorkJournalMaker/issues/32) — Save button hidden when editor window is at the bottom
+- [ ] **GATE:** Basic user workflow works end-to-end (verified via Playwright)
 
-## Test Health
-
-- [ ] [#81](https://github.com/lbnl-science-it/WorkJournalMaker/issues/81) — Write proper test coverage for work week, calendar, and web integration services (rewrite, not patch — per #60 post-mortem)
-
-## Desktop Packaging (PyInstaller + CI/CD)
-
-Steps 1–11 complete. Remaining:
+## Cluster D: Desktop Packaging
 
 - [ ] [#72](https://github.com/lbnl-science-it/WorkJournalMaker/issues/72) — Step 12: Build Automation Testing (CI/CD simulation)
 - [ ] Step 13: Release Management and Distribution


### PR DESCRIPTION
## Summary

- Reorganize `todo.md` from a flat bug list into prioritized clusters based on the 2026-05-08 issue triage session
- Clusters: T1 (test isolation), T2 (coverage rewrite), S (security hardening), U (UI bugs), D (desktop packaging)
- Each cluster has a **GATE** condition defining when it's complete
- Links to full triage design spec at `docs/superpowers/specs/2026-05-08-issue-triage-design.md`

Extracted from PR #123 to keep test isolation fixes and project management changes in separate PRs.

## Test plan

- [x] No code changes — documentation only
- [x] Verify all issue links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)