### PR TITLE
feat(auth): add pluggable authentication to web API (#87)

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -267,6 +267,7 @@ class ConfigManager:
             'WJS_MAX_FILE_SIZE_MB': ['processing', 'max_file_size_mb'],
             'WJS_LOG_LEVEL': ['logging', 'level'],
             'WJS_LOG_DIR': ['logging', 'log_dir'],
+            'WJS_AUTH_SECRET_KEY': ['auth', 'secret_key'],
         }
         
         for env_var, config_path in env_mappings.items():
@@ -287,12 +288,6 @@ class ConfigManager:
                     current[final_key] = value.upper()
                 else:
                     current[final_key] = value
-
-        auth_secret = os.getenv('WJM_AUTH_SECRET_KEY')
-        if auth_secret:
-            if 'auth' not in config_dict:
-                config_dict['auth'] = {}
-            config_dict['auth']['secret_key'] = auth_secret
 
         return config_dict
     
@@ -562,6 +557,13 @@ class ConfigManager:
                 'include_module_names': True,
                 'max_file_size_mb': 10,
                 'backup_count': 5
+            },
+            'auth': {
+                'enabled': False,
+                'provider': 'local',
+                'secret_key': '',
+                'access_token_ttl': 1800,
+                'refresh_token_ttl': 604800,
             }
         }
         

--- a/config_manager.py
+++ b/config_manager.py
@@ -114,6 +114,16 @@ class ProcessingConfig:
 
 
 @dataclass
+class AuthConfig:
+    """Configuration for authentication and authorization."""
+    enabled: bool = False
+    provider: str = "local"
+    secret_key: str = ""
+    access_token_ttl: int = 1800
+    refresh_token_ttl: int = 604800
+
+
+@dataclass
 class AppConfig:
     """Complete application configuration."""
     bedrock: BedrockConfig = field(default_factory=BedrockConfig)
@@ -122,6 +132,7 @@ class AppConfig:
     llm: LLMConfig = field(default_factory=LLMConfig)
     processing: ProcessingConfig = field(default_factory=ProcessingConfig)
     logging: LogConfig = field(default_factory=LogConfig)
+    auth: AuthConfig = field(default_factory=AuthConfig)
 
 
 class ConfigManager:
@@ -267,7 +278,7 @@ class ConfigManager:
                     if key not in current:
                         current[key] = {}
                     current = current[key]
-                
+
                 # Convert value to appropriate type
                 final_key = config_path[-1]
                 if final_key == 'max_file_size_mb':
@@ -276,7 +287,13 @@ class ConfigManager:
                     current[final_key] = value.upper()
                 else:
                     current[final_key] = value
-        
+
+        auth_secret = os.getenv('WJM_AUTH_SECRET_KEY')
+        if auth_secret:
+            if 'auth' not in config_dict:
+                config_dict['auth'] = {}
+            config_dict['auth']['secret_key'] = auth_secret
+
         return config_dict
     
     def _dict_to_config(self, config_dict: Dict[str, Any]) -> AppConfig:
@@ -358,13 +375,24 @@ class ConfigManager:
             backup_count=logging_dict.get('backup_count', LogConfig.backup_count)
         )
         
+        # Extract auth configuration
+        auth_dict = config_dict.get('auth', {})
+        auth_config = AuthConfig(
+            enabled=auth_dict.get('enabled', AuthConfig.enabled),
+            provider=auth_dict.get('provider', AuthConfig.provider),
+            secret_key=auth_dict.get('secret_key', AuthConfig.secret_key),
+            access_token_ttl=auth_dict.get('access_token_ttl', AuthConfig.access_token_ttl),
+            refresh_token_ttl=auth_dict.get('refresh_token_ttl', AuthConfig.refresh_token_ttl),
+        )
+
         return AppConfig(
             bedrock=bedrock_config,
             google_genai=google_genai_config,
             cborg=cborg_config,
             llm=llm_config,
             processing=processing_config,
-            logging=logging_config
+            logging=logging_config,
+            auth=auth_config,
         )
     
     def _validate_config(self, config: AppConfig) -> None:

--- a/docs/superpowers/plans/2026-05-08-authentication.md
+++ b/docs/superpowers/plans/2026-05-08-authentication.md
@@ -38,7 +38,7 @@
 
 ---
 
-## Task 1: Add Dependencies
+## Task 1: Add Dependencies ✅ DONE
 
 **Files:**
 - Modify: `requirements.txt`
@@ -66,7 +66,7 @@ git commit -m "feat(auth): add PyJWT and bcrypt dependencies for #87"
 
 ---
 
-## Task 2: Add AuthConfig to Configuration
+## Task 2: Add AuthConfig to Configuration ✅ DONE
 
 **Files:**
 - Modify: `config_manager.py:117-124` (AppConfig dataclass)
@@ -201,7 +201,7 @@ git commit -m "feat(auth): add AuthConfig dataclass with env var override for #8
 
 ---
 
-## Task 3: Add Database Models (UserAccount, RefreshToken)
+## Task 3: Add Database Models (UserAccount, RefreshToken) ✅ DONE
 
 **Files:**
 - Modify: `web/database.py:27-108` (add models after existing ones)
@@ -350,7 +350,7 @@ git commit -m "feat(auth): add UserAccount and RefreshToken database models for 
 
 ---
 
-## Task 4: Implement JWT Utilities and Core Auth Types
+## Task 4: Implement JWT Utilities and Core Auth Types ✅ DONE
 
 **Files:**
 - Create: `web/auth.py`
@@ -500,7 +500,7 @@ git commit -m "feat(auth): add User/TokenPair types, JWT encode/decode, AuthProv
 
 ---
 
-## Task 5: Implement FastAPI Auth Dependencies
+## Task 5: Implement FastAPI Auth Dependencies ✅ DONE
 
 **Files:**
 - Modify: `web/auth.py`

--- a/docs/superpowers/plans/2026-05-08-authentication.md
+++ b/docs/superpowers/plans/2026-05-08-authentication.md
@@ -1,0 +1,2043 @@
+# Authentication System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add pluggable authentication to all web API endpoints, closing issue #87 (unauthenticated access to destructive operations).
+
+**Architecture:** FastAPI dependency injection with a `Protocol`-based auth provider. Local username/password provider first (bcrypt + JWT). Auth-optional mode via config toggle preserves backward compatibility. Two roles: `user` and `admin`.
+
+**Tech Stack:** PyJWT, bcrypt, SQLAlchemy (async, existing), FastAPI dependency injection
+
+**Spec:** `docs/superpowers/specs/2026-05-08-authentication-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| **Create:** `web/auth.py` | `AuthProvider` protocol, `User`/`TokenPair` dataclasses, JWT encode/decode, FastAPI dependencies (`get_current_user`, `require_admin`) |
+| **Create:** `web/providers/__init__.py` | Package init |
+| **Create:** `web/providers/local.py` | Local auth provider: bcrypt password verify, JWT token issue, refresh token management |
+| **Create:** `web/api/auth.py` | Auth API router: `/api/auth/login`, `/refresh`, `/logout`, `/me` |
+| **Create:** `web/manage.py` | CLI tool for `create-admin` and `list-users` |
+| **Create:** `tests/test_auth.py` | Unit tests for JWT utilities, dependencies, auth-disabled mode |
+| **Create:** `tests/test_auth_provider_local.py` | Unit tests for local provider: authenticate, validate, refresh |
+| **Create:** `tests/test_auth_api.py` | Integration tests for auth endpoints |
+| **Create:** `tests/test_auth_protected.py` | Tests that existing endpoints enforce auth correctly |
+| **Create:** `tests/test_manage.py` | Tests for CLI management tool |
+| **Modify:** `web/database.py` | Add `UserAccount` and `RefreshToken` ORM models, add `user_id` column to `JournalEntryIndex` |
+| **Modify:** `config_manager.py` | Add `AuthConfig` dataclass, wire into `AppConfig` |
+| **Modify:** `web/app.py` | Register auth router, initialize auth provider on startup |
+| **Modify:** `web/api/entries.py` | Add `get_current_user` dependency, filter entries by `user_id` |
+| **Modify:** `web/api/settings.py` | Add `require_admin` dependency to destructive endpoints |
+| **Modify:** `web/api/sync.py` | Add `require_admin` dependency to scheduler control endpoints |
+| **Modify:** `web/api/health.py` | Add `require_admin` to `/config` and `/metrics`, leave `/` public |
+| **Modify:** `requirements.txt` | Add `PyJWT` and `bcrypt` |
+| **Modify:** `tests/conftest.py` | Add `auth_disabled_client` and `authenticated_client` fixtures |
+
+---
+
+## Task 1: Add Dependencies
+
+**Files:**
+- Modify: `requirements.txt`
+
+- [ ] **Step 1: Add PyJWT and bcrypt to requirements**
+
+```
+# At the end of requirements.txt, add:
+# Authentication
+PyJWT>=2.8.0
+bcrypt>=4.0.0
+```
+
+- [ ] **Step 2: Install dependencies**
+
+Run: `pyenv activate WorkJournal && pip install PyJWT>=2.8.0 bcrypt>=4.0.0`
+Expected: Both packages install successfully
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add requirements.txt
+git commit -m "feat(auth): add PyJWT and bcrypt dependencies for #87"
+```
+
+---
+
+## Task 2: Add AuthConfig to Configuration
+
+**Files:**
+- Modify: `config_manager.py:117-124` (AppConfig dataclass)
+- Test: `tests/test_auth.py` (new)
+
+- [ ] **Step 1: Write failing test for AuthConfig defaults**
+
+Create `tests/test_auth.py`:
+
+```python
+# ABOUTME: Unit tests for auth configuration, JWT utilities, and FastAPI dependencies.
+# ABOUTME: Validates auth-disabled mode, token lifecycle, and role-based access control.
+
+import pytest
+from config_manager import AppConfig, AuthConfig
+
+
+class TestAuthConfig:
+    """Tests for AuthConfig dataclass and its integration with AppConfig."""
+
+    def test_auth_config_defaults(self):
+        config = AuthConfig()
+        assert config.enabled is False
+        assert config.provider == "local"
+        assert config.secret_key == ""
+        assert config.access_token_ttl == 1800
+        assert config.refresh_token_ttl == 604800
+
+    def test_app_config_includes_auth(self):
+        config = AppConfig()
+        assert hasattr(config, "auth")
+        assert isinstance(config.auth, AuthConfig)
+        assert config.auth.enabled is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestAuthConfig -v`
+Expected: FAIL — `ImportError: cannot import name 'AuthConfig'`
+
+- [ ] **Step 3: Implement AuthConfig**
+
+In `config_manager.py`, add the dataclass before `AppConfig` (after `ProcessingConfig` around line 114):
+
+```python
+@dataclass
+class AuthConfig:
+    """Configuration for authentication and authorization."""
+    enabled: bool = False
+    provider: str = "local"
+    secret_key: str = ""
+    access_token_ttl: int = 1800
+    refresh_token_ttl: int = 604800
+```
+
+Add `auth` field to `AppConfig`:
+
+```python
+@dataclass
+class AppConfig:
+    """Complete application configuration."""
+    bedrock: BedrockConfig = field(default_factory=BedrockConfig)
+    google_genai: GoogleGenAIConfig = field(default_factory=GoogleGenAIConfig)
+    cborg: CBORGConfig = field(default_factory=CBORGConfig)
+    llm: LLMConfig = field(default_factory=LLMConfig)
+    processing: ProcessingConfig = field(default_factory=ProcessingConfig)
+    logging: LogConfig = field(default_factory=LogConfig)
+    auth: AuthConfig = field(default_factory=AuthConfig)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestAuthConfig -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Add config-file loading for auth section**
+
+In `ConfigManager._load_config()` (around line 186), the method calls `_build_config_from_dict`. Add auth parsing in the `_build_config_from_dict` method. Find where the other configs are built (look for `bedrock_dict`, `google_genai_dict`, etc.) and add:
+
+```python
+auth_dict = config_dict.get('auth', {})
+config.auth = AuthConfig(
+    enabled=auth_dict.get('enabled', AuthConfig.enabled),
+    provider=auth_dict.get('provider', AuthConfig.provider),
+    secret_key=auth_dict.get('secret_key', AuthConfig.secret_key),
+    access_token_ttl=auth_dict.get('access_token_ttl', AuthConfig.access_token_ttl),
+    refresh_token_ttl=auth_dict.get('refresh_token_ttl', AuthConfig.refresh_token_ttl),
+)
+```
+
+- [ ] **Step 6: Add environment variable override for secret key**
+
+In `ConfigManager._apply_env_overrides()`, add:
+
+```python
+auth_secret = os.getenv('WJM_AUTH_SECRET_KEY')
+if auth_secret:
+    config.auth.secret_key = auth_secret
+```
+
+- [ ] **Step 7: Write and run test for env var override**
+
+Add to `tests/test_auth.py`:
+
+```python
+import os
+from unittest.mock import patch
+from config_manager import ConfigManager
+
+
+class TestAuthConfigLoading:
+    """Tests for loading auth config from files and environment."""
+
+    def test_secret_key_from_env_var(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("auth:\n  enabled: true\n")
+        with patch.dict(os.environ, {"WJM_AUTH_SECRET_KEY": "test-secret-key-12345"}):
+            manager = ConfigManager(config_path=config_file)
+            assert manager.config.auth.secret_key == "test-secret-key-12345"
+            assert manager.config.auth.enabled is True
+```
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add config_manager.py tests/test_auth.py
+git commit -m "feat(auth): add AuthConfig dataclass with env var override for #87"
+```
+
+---
+
+## Task 3: Add Database Models (UserAccount, RefreshToken)
+
+**Files:**
+- Modify: `web/database.py:27-108` (add models after existing ones)
+- Test: `tests/test_auth.py` (extend)
+
+- [ ] **Step 1: Write failing test for UserAccount model**
+
+Add to `tests/test_auth.py`:
+
+```python
+import asyncio
+from web.database import DatabaseManager, UserAccount, RefreshToken
+
+
+class TestAuthDatabaseModels:
+    """Tests for auth-related database models."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_auth.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    def test_create_user_account(self, db):
+        from sqlalchemy import select
+        import uuid
+
+        async def _test():
+            async with db.get_session() as session:
+                user = UserAccount(
+                    id=str(uuid.uuid4()),
+                    username="testadmin",
+                    password_hash="$2b$12$fakehash",
+                    role="admin",
+                    is_active=True,
+                )
+                session.add(user)
+                await session.commit()
+
+                stmt = select(UserAccount).where(UserAccount.username == "testadmin")
+                result = await session.execute(stmt)
+                found = result.scalar_one()
+                assert found.username == "testadmin"
+                assert found.role == "admin"
+                assert found.is_active is True
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_create_refresh_token(self, db):
+        from sqlalchemy import select
+        import uuid
+        from datetime import datetime, timedelta, timezone
+
+        async def _test():
+            async with db.get_session() as session:
+                user_id = str(uuid.uuid4())
+                user = UserAccount(
+                    id=user_id,
+                    username="tokenuser",
+                    password_hash="$2b$12$fakehash",
+                    role="user",
+                )
+                session.add(user)
+                await session.commit()
+
+                token = RefreshToken(
+                    id=str(uuid.uuid4()),
+                    user_id=user_id,
+                    token_hash="sha256hashvalue",
+                    expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+                )
+                session.add(token)
+                await session.commit()
+
+                stmt = select(RefreshToken).where(RefreshToken.user_id == user_id)
+                result = await session.execute(stmt)
+                found = result.scalar_one()
+                assert found.token_hash == "sha256hashvalue"
+                assert found.revoked is False
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestAuthDatabaseModels -v`
+Expected: FAIL — `ImportError: cannot import name 'UserAccount'`
+
+- [ ] **Step 3: Implement UserAccount and RefreshToken models**
+
+In `web/database.py`, add these models after the `SyncStatus` class (around line 101), before the Index definitions:
+
+```python
+class UserAccount(Base):
+    """User account for authentication (local provider)."""
+    __tablename__ = "users"
+
+    id = Column(String, primary_key=True)
+    username = Column(String, unique=True, nullable=False, index=True)
+    password_hash = Column(String, nullable=False)
+    role = Column(String, nullable=False, default="user")
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, default=now_utc)
+    modified_at = Column(DateTime, default=now_utc, onupdate=now_utc)
+
+
+class RefreshToken(Base):
+    """Revocable refresh token (stores hash, not raw token)."""
+    __tablename__ = "refresh_tokens"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(String, nullable=False, index=True)
+    token_hash = Column(String, nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    revoked = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime, default=now_utc)
+```
+
+Add indexes with the existing index definitions:
+
+```python
+Index('idx_users_username', UserAccount.username)
+Index('idx_refresh_tokens_user', RefreshToken.user_id)
+Index('idx_refresh_tokens_hash', RefreshToken.token_hash)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestAuthDatabaseModels -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/database.py tests/test_auth.py
+git commit -m "feat(auth): add UserAccount and RefreshToken database models for #87"
+```
+
+---
+
+## Task 4: Implement JWT Utilities and Core Auth Types
+
+**Files:**
+- Create: `web/auth.py`
+- Test: `tests/test_auth.py` (extend)
+
+- [ ] **Step 1: Write failing tests for User and TokenPair dataclasses**
+
+Add to `tests/test_auth.py`:
+
+```python
+from web.auth import User, TokenPair
+
+
+class TestAuthTypes:
+    """Tests for User and TokenPair dataclasses."""
+
+    def test_user_creation(self):
+        user = User(id="u1", username="alice", role="user")
+        assert user.id == "u1"
+        assert user.username == "alice"
+        assert user.role == "user"
+
+    def test_token_pair_creation(self):
+        pair = TokenPair(access_token="acc", refresh_token="ref")
+        assert pair.access_token == "acc"
+        assert pair.refresh_token == "ref"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestAuthTypes -v`
+Expected: FAIL — `ImportError: cannot import name 'User' from 'web.auth'`
+
+- [ ] **Step 3: Write failing tests for JWT encode/decode**
+
+Add to `tests/test_auth.py`:
+
+```python
+from web.auth import encode_access_token, decode_access_token
+from datetime import datetime, timezone
+
+
+class TestJWTUtilities:
+    """Tests for JWT token encoding and decoding."""
+
+    SECRET = "test-secret-key-for-jwt-testing"
+
+    def test_encode_decode_roundtrip(self):
+        user = User(id="u1", username="alice", role="user")
+        token = encode_access_token(user, self.SECRET, ttl_seconds=300)
+        decoded = decode_access_token(token, self.SECRET)
+        assert decoded["user_id"] == "u1"
+        assert decoded["username"] == "alice"
+        assert decoded["role"] == "user"
+        assert "exp" in decoded
+
+    def test_decode_expired_token_raises(self):
+        user = User(id="u1", username="alice", role="user")
+        token = encode_access_token(user, self.SECRET, ttl_seconds=-1)
+        with pytest.raises(Exception):
+            decode_access_token(token, self.SECRET)
+
+    def test_decode_invalid_token_raises(self):
+        with pytest.raises(Exception):
+            decode_access_token("not.a.valid.token", self.SECRET)
+
+    def test_decode_wrong_secret_raises(self):
+        user = User(id="u1", username="alice", role="user")
+        token = encode_access_token(user, self.SECRET, ttl_seconds=300)
+        with pytest.raises(Exception):
+            decode_access_token(token, "wrong-secret")
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestJWTUtilities -v`
+Expected: FAIL — `ImportError`
+
+- [ ] **Step 5: Implement web/auth.py with types and JWT utilities**
+
+Create `web/auth.py`:
+
+```python
+# ABOUTME: Authentication protocol, user model, JWT utilities, and FastAPI dependencies.
+# ABOUTME: Provides the pluggable auth provider interface and token validation.
+
+from dataclasses import dataclass
+from typing import Protocol, Optional
+from datetime import datetime, timedelta, timezone
+
+import jwt
+
+
+@dataclass
+class User:
+    """Authenticated user identity."""
+    id: str
+    username: str
+    role: str
+
+
+@dataclass
+class TokenPair:
+    """Access and refresh token pair returned after authentication."""
+    access_token: str
+    refresh_token: str
+
+
+class AuthProvider(Protocol):
+    """Pluggable authentication provider interface."""
+
+    async def authenticate(self, credentials: dict) -> TokenPair: ...
+    async def validate_token(self, token: str) -> User: ...
+    async def refresh_token(self, raw_refresh_token: str) -> TokenPair: ...
+    async def revoke_token(self, raw_refresh_token: str) -> None: ...
+
+
+def encode_access_token(user: User, secret: str, ttl_seconds: int = 1800) -> str:
+    """Encode a JWT access token for the given user."""
+    now = datetime.now(timezone.utc)
+    payload = {
+        "user_id": user.id,
+        "username": user.username,
+        "role": user.role,
+        "iat": now,
+        "exp": now + timedelta(seconds=ttl_seconds),
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def decode_access_token(token: str, secret: str) -> dict:
+    """Decode and validate a JWT access token. Raises on expiry or bad signature."""
+    return jwt.decode(token, secret, algorithms=["HS256"])
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestAuthTypes tests/test_auth.py::TestJWTUtilities -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/auth.py tests/test_auth.py
+git commit -m "feat(auth): add User/TokenPair types, JWT encode/decode, AuthProvider protocol for #87"
+```
+
+---
+
+## Task 5: Implement FastAPI Auth Dependencies
+
+**Files:**
+- Modify: `web/auth.py`
+- Test: `tests/test_auth.py` (extend)
+
+- [ ] **Step 1: Write failing tests for get_current_user dependency**
+
+Add to `tests/test_auth.py`:
+
+```python
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import HTTPException
+from web.auth import get_current_user, require_admin, User, encode_access_token
+from config_manager import AuthConfig
+
+
+class TestGetCurrentUser:
+    """Tests for the get_current_user FastAPI dependency."""
+
+    SECRET = "test-secret-key-for-dependency-testing"
+
+    def _make_config(self, enabled=True):
+        return AuthConfig(enabled=enabled, secret_key=self.SECRET)
+
+    def _make_request(self, token=None):
+        request = MagicMock()
+        request.app.state.auth_config = self._make_config(enabled=True)
+        request.app.state.auth_provider = None
+        if token:
+            request.headers = {"authorization": f"Bearer {token}"}
+        else:
+            request.headers = {}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_user(self):
+        user = User(id="u1", username="alice", role="user")
+        token = encode_access_token(user, self.SECRET, ttl_seconds=300)
+        request = self._make_request(token)
+        result = await get_current_user(request)
+        assert result.id == "u1"
+        assert result.username == "alice"
+
+    @pytest.mark.asyncio
+    async def test_missing_header_raises_401(self):
+        request = self._make_request(token=None)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(request)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_raises_401(self):
+        request = self._make_request(token="garbage.token.here")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(request)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_auth_disabled_returns_default_admin(self):
+        request = MagicMock()
+        request.app.state.auth_config = self._make_config(enabled=False)
+        result = await get_current_user(request)
+        assert result.id == "default"
+        assert result.role == "admin"
+
+
+class TestRequireAdmin:
+    """Tests for the require_admin FastAPI dependency."""
+
+    @pytest.mark.asyncio
+    async def test_admin_user_passes(self):
+        user = User(id="u1", username="admin", role="admin")
+        result = await require_admin(user)
+        assert result.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_non_admin_raises_403(self):
+        user = User(id="u2", username="viewer", role="user")
+        with pytest.raises(HTTPException) as exc_info:
+            await require_admin(user)
+        assert exc_info.value.status_code == 403
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestGetCurrentUser tests/test_auth.py::TestRequireAdmin -v`
+Expected: FAIL — `ImportError: cannot import name 'get_current_user'`
+
+- [ ] **Step 3: Implement get_current_user and require_admin**
+
+Add to the bottom of `web/auth.py`:
+
+```python
+from fastapi import Request, Depends, HTTPException, status
+
+
+_DEFAULT_USER = User(id="default", username="default", role="admin")
+
+
+async def get_current_user(request: Request) -> User:
+    """FastAPI dependency: extract and validate the Bearer token, return User."""
+    auth_config = request.app.state.auth_config
+
+    if not auth_config.enabled:
+        return _DEFAULT_USER
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or invalid Authorization header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = auth_header[len("Bearer "):]
+    try:
+        payload = decode_access_token(token, auth_config.secret_key)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return User(
+        id=payload["user_id"],
+        username=payload["username"],
+        role=payload["role"],
+    )
+
+
+async def require_admin(user: User = Depends(get_current_user)) -> User:
+    """FastAPI dependency: require the current user to be an admin."""
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return user
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestGetCurrentUser tests/test_auth.py::TestRequireAdmin -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/auth.py tests/test_auth.py
+git commit -m "feat(auth): add get_current_user and require_admin FastAPI dependencies for #87"
+```
+
+---
+
+## Task 6: Implement Local Auth Provider
+
+**Files:**
+- Create: `web/providers/__init__.py`
+- Create: `web/providers/local.py`
+- Test: `tests/test_auth_provider_local.py` (new)
+
+- [ ] **Step 1: Create providers package**
+
+Create `web/providers/__init__.py`:
+
+```python
+# ABOUTME: Authentication provider package.
+# ABOUTME: Contains pluggable provider implementations (local, future SSO).
+```
+
+- [ ] **Step 2: Write failing tests for local provider**
+
+Create `tests/test_auth_provider_local.py`:
+
+```python
+# ABOUTME: Tests for the local username/password authentication provider.
+# ABOUTME: Validates password hashing, token issuance, refresh, and revocation.
+
+import asyncio
+import uuid
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from web.database import DatabaseManager, UserAccount
+from web.providers.local import LocalAuthProvider
+from web.auth import User, TokenPair, decode_access_token
+from config_manager import AuthConfig
+
+
+class TestLocalAuthProvider:
+    """Tests for LocalAuthProvider."""
+
+    SECRET = "test-secret-for-local-provider"
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_local_auth.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    @pytest.fixture
+    def config(self):
+        return AuthConfig(
+            enabled=True,
+            secret_key=self.SECRET,
+            access_token_ttl=300,
+            refresh_token_ttl=86400,
+        )
+
+    @pytest.fixture
+    def provider(self, db, config):
+        return LocalAuthProvider(db, config)
+
+    @pytest.fixture
+    def seeded_user(self, provider):
+        """Create a test user via the provider's hash utility."""
+        import bcrypt
+
+        async def _seed(db):
+            pw_hash = bcrypt.hashpw(b"correct-password", bcrypt.gensalt()).decode()
+            user_id = str(uuid.uuid4())
+            async with db.get_session() as session:
+                session.add(UserAccount(
+                    id=user_id,
+                    username="testuser",
+                    password_hash=pw_hash,
+                    role="user",
+                ))
+                await session.commit()
+            return user_id
+
+        loop = asyncio.new_event_loop()
+        user_id = loop.run_until_complete(_seed(provider.db))
+        loop.close()
+        return user_id
+
+    def test_authenticate_success(self, provider, seeded_user):
+        async def _test():
+            pair = await provider.authenticate({
+                "username": "testuser",
+                "password": "correct-password",
+            })
+            assert isinstance(pair, TokenPair)
+            assert pair.access_token
+            assert pair.refresh_token
+            payload = decode_access_token(pair.access_token, self.SECRET)
+            assert payload["username"] == "testuser"
+            assert payload["role"] == "user"
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_authenticate_wrong_password(self, provider, seeded_user):
+        async def _test():
+            with pytest.raises(Exception):
+                await provider.authenticate({
+                    "username": "testuser",
+                    "password": "wrong-password",
+                })
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_authenticate_unknown_user(self, provider):
+        async def _test():
+            with pytest.raises(Exception):
+                await provider.authenticate({
+                    "username": "nonexistent",
+                    "password": "anything",
+                })
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_authenticate_inactive_user(self, provider, db):
+        import bcrypt
+
+        async def _test():
+            pw_hash = bcrypt.hashpw(b"pass", bcrypt.gensalt()).decode()
+            async with db.get_session() as session:
+                session.add(UserAccount(
+                    id=str(uuid.uuid4()),
+                    username="inactive",
+                    password_hash=pw_hash,
+                    role="user",
+                    is_active=False,
+                ))
+                await session.commit()
+
+            with pytest.raises(Exception):
+                await provider.authenticate({
+                    "username": "inactive",
+                    "password": "pass",
+                })
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_validate_token(self, provider, seeded_user):
+        async def _test():
+            pair = await provider.authenticate({
+                "username": "testuser",
+                "password": "correct-password",
+            })
+            user = await provider.validate_token(pair.access_token)
+            assert user.username == "testuser"
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_refresh_token_success(self, provider, seeded_user):
+        async def _test():
+            pair = await provider.authenticate({
+                "username": "testuser",
+                "password": "correct-password",
+            })
+            new_pair = await provider.refresh_token(pair.refresh_token)
+            assert isinstance(new_pair, TokenPair)
+            assert new_pair.access_token != pair.access_token
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_revoke_token(self, provider, seeded_user):
+        async def _test():
+            pair = await provider.authenticate({
+                "username": "testuser",
+                "password": "correct-password",
+            })
+            await provider.revoke_token(pair.refresh_token)
+            with pytest.raises(Exception):
+                await provider.refresh_token(pair.refresh_token)
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth_provider_local.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'web.providers.local'`
+
+- [ ] **Step 4: Implement LocalAuthProvider**
+
+Create `web/providers/local.py`:
+
+```python
+# ABOUTME: Local username/password authentication provider using bcrypt and JWT.
+# ABOUTME: Manages user verification, token issuance, refresh token rotation, and revocation.
+
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import bcrypt
+from sqlalchemy import select
+
+from config_manager import AuthConfig
+from web.auth import AuthProvider, User, TokenPair, encode_access_token, decode_access_token
+from web.database import DatabaseManager, UserAccount, RefreshToken
+
+
+class AuthenticationError(Exception):
+    """Raised when authentication fails."""
+    pass
+
+
+class LocalAuthProvider:
+    """Authenticates users against local database with bcrypt-hashed passwords."""
+
+    def __init__(self, db: DatabaseManager, config: AuthConfig):
+        self.db = db
+        self.config = config
+
+    async def authenticate(self, credentials: dict) -> TokenPair:
+        """Verify username/password and return a token pair."""
+        username = credentials.get("username", "")
+        password = credentials.get("password", "")
+
+        async with self.db.get_session() as session:
+            stmt = select(UserAccount).where(UserAccount.username == username)
+            result = await session.execute(stmt)
+            account = result.scalar_one_or_none()
+
+        if account is None:
+            raise AuthenticationError("Invalid username or password")
+
+        if not account.is_active:
+            raise AuthenticationError("Account is disabled")
+
+        if not bcrypt.checkpw(password.encode(), account.password_hash.encode()):
+            raise AuthenticationError("Invalid username or password")
+
+        user = User(id=account.id, username=account.username, role=account.role)
+        return await self._issue_token_pair(user)
+
+    async def validate_token(self, token: str) -> User:
+        """Decode a JWT access token and return the User."""
+        payload = decode_access_token(token, self.config.secret_key)
+        return User(
+            id=payload["user_id"],
+            username=payload["username"],
+            role=payload["role"],
+        )
+
+    async def refresh_token(self, raw_refresh_token: str) -> TokenPair:
+        """Exchange a valid refresh token for a new token pair."""
+        token_hash = self._hash_refresh_token(raw_refresh_token)
+
+        async with self.db.get_session() as session:
+            stmt = select(RefreshToken).where(
+                RefreshToken.token_hash == token_hash,
+                RefreshToken.revoked == False,
+            )
+            result = await session.execute(stmt)
+            stored = result.scalar_one_or_none()
+
+            if stored is None:
+                raise AuthenticationError("Invalid or revoked refresh token")
+
+            if stored.expires_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
+                raise AuthenticationError("Refresh token has expired")
+
+            # Revoke the old token (rotation)
+            stored.revoked = True
+            await session.commit()
+
+        # Look up user to build new tokens
+        async with self.db.get_session() as session:
+            stmt = select(UserAccount).where(UserAccount.id == stored.user_id)
+            result = await session.execute(stmt)
+            account = result.scalar_one_or_none()
+
+        if account is None or not account.is_active:
+            raise AuthenticationError("User account not found or disabled")
+
+        user = User(id=account.id, username=account.username, role=account.role)
+        return await self._issue_token_pair(user)
+
+    async def revoke_token(self, raw_refresh_token: str) -> None:
+        """Revoke a refresh token (logout)."""
+        token_hash = self._hash_refresh_token(raw_refresh_token)
+
+        async with self.db.get_session() as session:
+            stmt = select(RefreshToken).where(RefreshToken.token_hash == token_hash)
+            result = await session.execute(stmt)
+            stored = result.scalar_one_or_none()
+            if stored:
+                stored.revoked = True
+                await session.commit()
+
+    async def _issue_token_pair(self, user: User) -> TokenPair:
+        """Create a new access + refresh token pair and persist the refresh token hash."""
+        access_token = encode_access_token(
+            user, self.config.secret_key, ttl_seconds=self.config.access_token_ttl
+        )
+        raw_refresh = uuid.uuid4().hex + uuid.uuid4().hex
+        token_hash = self._hash_refresh_token(raw_refresh)
+
+        async with self.db.get_session() as session:
+            session.add(RefreshToken(
+                id=str(uuid.uuid4()),
+                user_id=user.id,
+                token_hash=token_hash,
+                expires_at=datetime.now(timezone.utc) + timedelta(seconds=self.config.refresh_token_ttl),
+            ))
+            await session.commit()
+
+        return TokenPair(access_token=access_token, refresh_token=raw_refresh)
+
+    @staticmethod
+    def _hash_refresh_token(raw_token: str) -> str:
+        """SHA-256 hash a raw refresh token for storage."""
+        return hashlib.sha256(raw_token.encode()).hexdigest()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth_provider_local.py -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/providers/__init__.py web/providers/local.py tests/test_auth_provider_local.py
+git commit -m "feat(auth): implement LocalAuthProvider with bcrypt and refresh tokens for #87"
+```
+
+---
+
+## Task 7: Implement Auth API Endpoints
+
+**Files:**
+- Create: `web/api/auth.py`
+- Test: `tests/test_auth_api.py` (new)
+- Modify: `web/app.py` (register router, initialize provider on startup)
+
+- [ ] **Step 1: Write failing integration tests for auth endpoints**
+
+Create `tests/test_auth_api.py`:
+
+```python
+# ABOUTME: Integration tests for the /api/auth endpoints.
+# ABOUTME: Tests login, refresh, logout, and profile using TestClient.
+
+import asyncio
+import uuid
+import pytest
+import bcrypt
+from fastapi.testclient import TestClient
+
+from web.app import app
+from web.database import DatabaseManager, UserAccount
+from config_manager import AuthConfig
+
+
+@pytest.fixture
+def auth_client(tmp_path):
+    """TestClient with auth enabled and a seeded admin user."""
+    secret = "integration-test-secret-key"
+
+    with TestClient(app) as client:
+        # Set up auth config on app state
+        auth_config = AuthConfig(enabled=True, secret_key=secret)
+        app.state.auth_config = auth_config
+
+        # Set up temp DB
+        db = DatabaseManager(str(tmp_path / "test_auth_api.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+
+        # Seed an admin user
+        pw_hash = bcrypt.hashpw(b"admin-pass", bcrypt.gensalt()).decode()
+        user_id = str(uuid.uuid4())
+
+        async def _seed():
+            async with db.get_session() as session:
+                session.add(UserAccount(
+                    id=user_id,
+                    username="admin",
+                    password_hash=pw_hash,
+                    role="admin",
+                ))
+                await session.commit()
+
+        loop.run_until_complete(_seed())
+
+        # Initialize the local provider
+        from web.providers.local import LocalAuthProvider
+        provider = LocalAuthProvider(db, auth_config)
+        app.state.auth_provider = provider
+
+        yield client
+
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+
+class TestAuthLogin:
+    """Tests for POST /api/auth/login."""
+
+    def test_login_success(self, auth_client):
+        resp = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "admin-pass",
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "access_token" in body
+        assert "refresh_token" in body
+
+    def test_login_wrong_password(self, auth_client):
+        resp = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "wrong",
+        })
+        assert resp.status_code == 401
+
+    def test_login_unknown_user(self, auth_client):
+        resp = auth_client.post("/api/auth/login", json={
+            "username": "nobody",
+            "password": "anything",
+        })
+        assert resp.status_code == 401
+
+
+class TestAuthRefresh:
+    """Tests for POST /api/auth/refresh."""
+
+    def test_refresh_success(self, auth_client):
+        login = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "admin-pass",
+        })
+        refresh_token = login.json()["refresh_token"]
+
+        resp = auth_client.post("/api/auth/refresh", json={
+            "refresh_token": refresh_token,
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "access_token" in body
+        assert body["access_token"] != login.json()["access_token"]
+
+    def test_refresh_invalid_token(self, auth_client):
+        resp = auth_client.post("/api/auth/refresh", json={
+            "refresh_token": "not-a-real-token",
+        })
+        assert resp.status_code == 401
+
+
+class TestAuthLogout:
+    """Tests for POST /api/auth/logout."""
+
+    def test_logout_revokes_refresh_token(self, auth_client):
+        login = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "admin-pass",
+        })
+        tokens = login.json()
+        access = tokens["access_token"]
+        refresh = tokens["refresh_token"]
+
+        resp = auth_client.post(
+            "/api/auth/logout",
+            json={"refresh_token": refresh},
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert resp.status_code == 200
+
+        # Refresh token should now be invalid
+        resp = auth_client.post("/api/auth/refresh", json={
+            "refresh_token": refresh,
+        })
+        assert resp.status_code == 401
+
+
+class TestAuthMe:
+    """Tests for GET /api/auth/me."""
+
+    def test_me_returns_profile(self, auth_client):
+        login = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "admin-pass",
+        })
+        access = login.json()["access_token"]
+
+        resp = auth_client.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["username"] == "admin"
+        assert body["role"] == "admin"
+
+    def test_me_without_token_returns_401(self, auth_client):
+        resp = auth_client.get("/api/auth/me")
+        assert resp.status_code == 401
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth_api.py -v`
+Expected: FAIL — router not registered / 404
+
+- [ ] **Step 3: Implement auth API router**
+
+Create `web/api/auth.py`:
+
+```python
+# ABOUTME: REST API endpoints for authentication (login, refresh, logout, profile).
+# ABOUTME: Delegates to the active AuthProvider via app.state.
+
+from fastapi import APIRouter, HTTPException, Request, Depends, status
+from pydantic import BaseModel
+
+from web.auth import get_current_user, User
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class LogoutRequest(BaseModel):
+    refresh_token: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+
+
+class UserProfile(BaseModel):
+    id: str
+    username: str
+    role: str
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(body: LoginRequest, request: Request):
+    """Authenticate with username/password and receive a token pair."""
+    provider = request.app.state.auth_provider
+    try:
+        pair = await provider.authenticate({
+            "username": body.username,
+            "password": body.password,
+        })
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid username or password",
+        )
+    return TokenResponse(access_token=pair.access_token, refresh_token=pair.refresh_token)
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh(body: RefreshRequest, request: Request):
+    """Exchange a refresh token for a new token pair."""
+    provider = request.app.state.auth_provider
+    try:
+        pair = await provider.refresh_token(body.refresh_token)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+    return TokenResponse(access_token=pair.access_token, refresh_token=pair.refresh_token)
+
+
+@router.post("/logout")
+async def logout(
+    body: LogoutRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+):
+    """Revoke a refresh token (logout)."""
+    provider = request.app.state.auth_provider
+    await provider.revoke_token(body.refresh_token)
+    return {"detail": "Logged out"}
+
+
+@router.get("/me", response_model=UserProfile)
+async def me(user: User = Depends(get_current_user)):
+    """Return the current user's profile."""
+    return UserProfile(id=user.id, username=user.username, role=user.role)
+```
+
+- [ ] **Step 4: Wire auth into app startup**
+
+In `web/app.py`, add imports at the top:
+
+```python
+from web.auth import get_current_user, require_admin
+from web.api import auth as auth_api
+from web.providers.local import LocalAuthProvider
+from config_manager import AuthConfig
+```
+
+In the `startup()` method of `WorkJournalWebApp`, after config is loaded (around line 64, after `self.config = config_manager.get_config()`), add:
+
+```python
+# Initialize auth
+auth_config = self.config.auth
+if auth_config.enabled and not auth_config.secret_key:
+    raise RuntimeError(
+        "auth.enabled is true but no secret_key configured. "
+        "Set WJM_AUTH_SECRET_KEY environment variable."
+    )
+```
+
+In the `lifespan()` function, after setting `app.state.scheduler`, add:
+
+```python
+app.state.auth_config = web_app.config.auth
+if web_app.config.auth.enabled:
+    app.state.auth_provider = LocalAuthProvider(web_app.db_manager, web_app.config.auth)
+else:
+    app.state.auth_provider = None
+```
+
+Register the router with the existing routers:
+
+```python
+app.include_router(auth_api.router)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth_api.py -v`
+Expected: PASS (8 tests)
+
+- [ ] **Step 6: Run all existing tests to check for regressions**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/ -v --timeout=30 2>&1 | tail -30`
+Expected: All previously passing tests still pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/api/auth.py web/app.py tests/test_auth_api.py
+git commit -m "feat(auth): add auth API endpoints and wire provider into app startup for #87"
+```
+
+---
+
+## Task 8: Protect Existing Endpoints
+
+**Files:**
+- Modify: `web/api/entries.py`
+- Modify: `web/api/settings.py`
+- Modify: `web/api/sync.py`
+- Modify: `web/api/health.py`
+- Test: `tests/test_auth_protected.py` (new)
+- Modify: `tests/conftest.py`
+
+- [ ] **Step 1: Add test fixtures for auth in conftest**
+
+Add to `tests/conftest.py`:
+
+```python
+from config_manager import AuthConfig
+from web.auth import User, encode_access_token
+
+
+@pytest.fixture
+def auth_disabled_client(isolated_app_client):
+    """Client with auth disabled (existing behavior)."""
+    app.state.auth_config = AuthConfig(enabled=False)
+    app.state.auth_provider = None
+    yield isolated_app_client
+
+
+def _make_auth_header(role="user", secret="test-secret"):
+    """Helper: create a Bearer token header for the given role."""
+    user = User(id="test-user-id", username="testuser", role=role)
+    token = encode_access_token(user, secret, ttl_seconds=300)
+    return {"Authorization": f"Bearer {token}"}
+```
+
+- [ ] **Step 2: Write failing tests for protected endpoints**
+
+Create `tests/test_auth_protected.py`:
+
+```python
+# ABOUTME: Tests that existing endpoints enforce authentication correctly.
+# ABOUTME: Validates 401 without token, 200 with token, and 403 for admin-only routes.
+
+import asyncio
+import pytest
+from fastapi.testclient import TestClient
+
+from web.app import app
+from web.database import DatabaseManager
+from config_manager import AuthConfig
+from web.auth import User, encode_access_token
+
+
+SECRET = "protected-endpoint-test-secret"
+
+
+@pytest.fixture
+def protected_client(tmp_path):
+    """TestClient with auth ENABLED."""
+    with TestClient(app) as client:
+        auth_config = AuthConfig(enabled=True, secret_key=SECRET)
+        app.state.auth_config = auth_config
+        app.state.auth_provider = None
+
+        # Swap to temp DB
+        db = DatabaseManager(str(tmp_path / "test_protected.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+
+        orig_db = app.state.db_manager
+        app.state.db_manager = db
+        for name, svc in app.state._state.items():
+            if name != "db_manager" and hasattr(svc, "db_manager"):
+                svc.db_manager = db
+
+        yield client
+
+        app.state.db_manager = orig_db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+
+def _token(role="user"):
+    user = User(id="u1", username="tester", role=role)
+    return encode_access_token(user, SECRET, ttl_seconds=300)
+
+
+class TestEntriesAuth:
+    """Entries endpoints require user-level auth."""
+
+    def test_list_entries_no_token_401(self, protected_client):
+        resp = protected_client.get("/api/entries/")
+        assert resp.status_code == 401
+
+    def test_list_entries_with_token_200(self, protected_client):
+        resp = protected_client.get(
+            "/api/entries/",
+            headers={"Authorization": f"Bearer {_token()}"},
+        )
+        assert resp.status_code == 200
+
+
+class TestSettingsAuth:
+    """Settings reset requires admin auth."""
+
+    def test_reset_all_no_token_401(self, protected_client):
+        resp = protected_client.post("/api/settings/reset-all")
+        assert resp.status_code == 401
+
+    def test_reset_all_user_role_403(self, protected_client):
+        resp = protected_client.post(
+            "/api/settings/reset-all",
+            headers={"Authorization": f"Bearer {_token('user')}"},
+        )
+        assert resp.status_code == 403
+
+    def test_reset_all_admin_role_allowed(self, protected_client):
+        resp = protected_client.post(
+            "/api/settings/reset-all",
+            headers={"Authorization": f"Bearer {_token('admin')}"},
+        )
+        # Should not be 401 or 403
+        assert resp.status_code not in (401, 403)
+
+
+class TestSyncAuth:
+    """Sync scheduler endpoints require admin auth."""
+
+    def test_full_sync_no_token_401(self, protected_client):
+        resp = protected_client.post("/api/sync/full")
+        assert resp.status_code == 401
+
+    def test_full_sync_user_role_403(self, protected_client):
+        resp = protected_client.post(
+            "/api/sync/full",
+            headers={"Authorization": f"Bearer {_token('user')}"},
+        )
+        assert resp.status_code == 403
+
+
+class TestAuthDisabled:
+    """When auth is disabled, all endpoints work without tokens."""
+
+    def test_entries_accessible(self, isolated_app_client):
+        app.state.auth_config = AuthConfig(enabled=False)
+        resp = isolated_app_client.get("/api/entries/")
+        assert resp.status_code == 200
+
+    def test_settings_accessible(self, isolated_app_client):
+        app.state.auth_config = AuthConfig(enabled=False)
+        resp = isolated_app_client.get("/api/settings/")
+        assert resp.status_code == 200
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth_protected.py -v`
+Expected: FAIL — endpoints return 200 without tokens (not yet protected)
+
+- [ ] **Step 4: Add auth dependency to entries.py**
+
+In `web/api/entries.py`, add import:
+
+```python
+from web.auth import get_current_user, User
+from fastapi import Depends
+```
+
+Add `user: User = Depends(get_current_user)` parameter to each endpoint function. For example, `list_entries` becomes:
+
+```python
+@router.get("/", response_model=RecentEntriesResponse)
+async def list_entries(
+    start_date: Optional[date] = Query(None, description="Start date filter"),
+    end_date: Optional[date] = Query(None, description="End date filter"),
+    has_content: Optional[bool] = Query(None, description="Filter by content presence"),
+    limit: int = Query(10, ge=1, le=100, description="Number of entries to return"),
+    offset: int = Query(0, ge=0, description="Offset for pagination"),
+    sort_by: str = Query("date", description="Sort field"),
+    sort_order: str = Query("desc", regex="^(asc|desc)$", description="Sort order"),
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user),
+):
+```
+
+Repeat for all endpoints in entries.py. The `user` parameter does not need to be used in the function body yet — the dependency itself enforces the check.
+
+- [ ] **Step 5: Add admin dependency to settings.py destructive endpoints**
+
+In `web/api/settings.py`, add import:
+
+```python
+from web.auth import get_current_user, require_admin, User
+```
+
+Add `user: User = Depends(get_current_user)` to read endpoints (GET).
+
+Add `user: User = Depends(require_admin)` to destructive endpoints: `reset_all_settings`, `import_settings`, and any PUT/DELETE.
+
+- [ ] **Step 6: Add admin dependency to sync.py**
+
+In `web/api/sync.py`, add import:
+
+```python
+from web.auth import require_admin, User
+```
+
+Add `user: User = Depends(require_admin)` to: `full_sync`, `scheduler_stop`, `scheduler_config` (PUT), and any other state-changing endpoints.
+
+- [ ] **Step 7: Add admin dependency to health.py selective endpoints**
+
+In `web/api/health.py`, add import:
+
+```python
+from web.auth import get_current_user, require_admin, User
+```
+
+Leave `GET /api/health/` public (no dependency). Add `user: User = Depends(require_admin)` to `/config` and `/metrics`.
+
+- [ ] **Step 8: Update conftest.py with auth_config default**
+
+In `tests/conftest.py`, inside the `isolated_app_client` fixture, after setting up the temp database and before `yield client`, add:
+
+```python
+app.state.auth_config = AuthConfig(enabled=False)
+app.state.auth_provider = None
+```
+
+Add imports at top:
+
+```python
+from config_manager import AuthConfig
+```
+
+This ensures all existing tests continue to work with auth disabled.
+
+- [ ] **Step 9: Run protected endpoint tests**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth_protected.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 10: Run all tests to verify no regressions**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/ -v --timeout=30 2>&1 | tail -40`
+Expected: All previously passing tests still pass
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add web/api/entries.py web/api/settings.py web/api/sync.py web/api/health.py tests/conftest.py tests/test_auth_protected.py
+git commit -m "feat(auth): protect all API endpoints with auth dependencies for #87"
+```
+
+---
+
+## Task 9: Implement CLI Management Tool
+
+**Files:**
+- Create: `web/manage.py`
+- Test: `tests/test_manage.py` (new)
+
+- [ ] **Step 1: Write failing tests for manage.py**
+
+Create `tests/test_manage.py`:
+
+```python
+# ABOUTME: Tests for the CLI user management tool (create-admin, list-users).
+# ABOUTME: Validates user creation with proper password hashing and role assignment.
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+from io import StringIO
+
+from web.database import DatabaseManager, UserAccount
+from web.manage import create_admin, list_users
+
+
+class TestCreateAdmin:
+    """Tests for the create-admin CLI command."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_manage.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    def test_create_admin_user(self, db):
+        import bcrypt
+        from sqlalchemy import select
+
+        async def _test():
+            await create_admin(db, "myadmin", "securepass123")
+
+            async with db.get_session() as session:
+                stmt = select(UserAccount).where(UserAccount.username == "myadmin")
+                result = await session.execute(stmt)
+                user = result.scalar_one()
+                assert user.role == "admin"
+                assert user.is_active is True
+                assert bcrypt.checkpw(b"securepass123", user.password_hash.encode())
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_create_duplicate_username_raises(self, db):
+        async def _test():
+            await create_admin(db, "dup", "pass1")
+            with pytest.raises(Exception):
+                await create_admin(db, "dup", "pass2")
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+
+class TestListUsers:
+    """Tests for the list-users CLI command."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_manage_list.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    def test_list_empty(self, db):
+        async def _test():
+            users = await list_users(db)
+            assert users == []
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_list_after_create(self, db):
+        async def _test():
+            await create_admin(db, "admin1", "pass")
+            users = await list_users(db)
+            assert len(users) == 1
+            assert users[0]["username"] == "admin1"
+            assert users[0]["role"] == "admin"
+            assert "password_hash" not in users[0]
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_manage.py -v`
+Expected: FAIL — `ImportError: cannot import name 'create_admin' from 'web.manage'`
+
+- [ ] **Step 3: Implement web/manage.py**
+
+Create `web/manage.py`:
+
+```python
+# ABOUTME: CLI tool for user account management (create-admin, list-users).
+# ABOUTME: Bootstraps the first admin user without requiring API authentication.
+
+import argparse
+import asyncio
+import getpass
+import sys
+import uuid
+
+import bcrypt
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from web.database import DatabaseManager, UserAccount
+
+
+async def create_admin(db: DatabaseManager, username: str, password: str) -> str:
+    """Create an admin user account. Returns the new user's ID."""
+    pw_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    user_id = str(uuid.uuid4())
+
+    async with db.get_session() as session:
+        stmt = select(UserAccount).where(UserAccount.username == username)
+        result = await session.execute(stmt)
+        if result.scalar_one_or_none() is not None:
+            raise ValueError(f"Username '{username}' already exists")
+
+        session.add(UserAccount(
+            id=user_id,
+            username=username,
+            password_hash=pw_hash,
+            role="admin",
+            is_active=True,
+        ))
+        await session.commit()
+
+    return user_id
+
+
+async def list_users(db: DatabaseManager) -> list:
+    """List all user accounts (without password hashes)."""
+    async with db.get_session() as session:
+        stmt = select(UserAccount).order_by(UserAccount.created_at)
+        result = await session.execute(stmt)
+        accounts = result.scalars().all()
+
+    return [
+        {
+            "id": a.id,
+            "username": a.username,
+            "role": a.role,
+            "is_active": a.is_active,
+            "created_at": a.created_at.isoformat() if a.created_at else None,
+        }
+        for a in accounts
+    ]
+
+
+async def _main(args: argparse.Namespace) -> None:
+    db = DatabaseManager()
+    await db.initialize()
+
+    if args.command == "create-admin":
+        password = args.password or getpass.getpass("Password: ")
+        user_id = await create_admin(db, args.username, password)
+        print(f"Admin user '{args.username}' created (id: {user_id})")
+
+    elif args.command == "list-users":
+        users = await list_users(db)
+        if not users:
+            print("No users found.")
+        else:
+            for u in users:
+                status = "active" if u["is_active"] else "disabled"
+                print(f"  {u['username']}  role={u['role']}  {status}  id={u['id']}")
+
+    if db.engine:
+        await db.engine.dispose()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Work Journal Maker user management")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create_parser = sub.add_parser("create-admin", help="Create an admin user")
+    create_parser.add_argument("--username", required=True)
+    create_parser.add_argument("--password", default=None, help="Password (prompted if omitted)")
+
+    sub.add_parser("list-users", help="List all users")
+
+    args = parser.parse_args()
+    asyncio.run(_main(args))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_manage.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/manage.py tests/test_manage.py
+git commit -m "feat(auth): add CLI management tool for user creation for #87"
+```
+
+---
+
+## Task 10: Add user_id Column to JournalEntryIndex
+
+**Files:**
+- Modify: `web/database.py:34-56` (JournalEntryIndex model)
+- Test: `tests/test_auth.py` (extend)
+
+- [ ] **Step 1: Write failing test for user_id column**
+
+Add to `tests/test_auth.py`:
+
+```python
+from web.database import JournalEntryIndex
+from datetime import date
+
+
+class TestJournalEntryUserScoping:
+    """Tests for user_id column on journal entries."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_scoping.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    def test_entry_has_user_id_column(self):
+        assert hasattr(JournalEntryIndex, "user_id")
+
+    def test_entry_default_user_id(self, db):
+        from sqlalchemy import select
+
+        async def _test():
+            async with db.get_session() as session:
+                entry = JournalEntryIndex(
+                    date=date(2026, 5, 1),
+                    file_path="/tmp/test.txt",
+                    week_ending_date=date(2026, 5, 2),
+                )
+                session.add(entry)
+                await session.commit()
+
+                stmt = select(JournalEntryIndex).where(
+                    JournalEntryIndex.date == date(2026, 5, 1)
+                )
+                result = await session.execute(stmt)
+                found = result.scalar_one()
+                assert found.user_id == "default"
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestJournalEntryUserScoping -v`
+Expected: FAIL — `AttributeError: type object 'JournalEntryIndex' has no attribute 'user_id'`
+
+- [ ] **Step 3: Add user_id column to JournalEntryIndex**
+
+In `web/database.py`, add to the `JournalEntryIndex` model (after `has_content`):
+
+```python
+    # User scoping for multi-user deployments
+    user_id = Column(String, nullable=False, default="default", index=True)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py::TestJournalEntryUserScoping -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Run full test suite for regressions**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/ -v --timeout=30 2>&1 | tail -30`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/database.py tests/test_auth.py
+git commit -m "feat(auth): add user_id column to JournalEntryIndex for #87"
+```
+
+---
+
+## Task 11: Add WebSocket Token Validation
+
+**Files:**
+- Modify: `web/app.py:267-290` (general WebSocket endpoint)
+- Test: `tests/test_auth_protected.py` (extend)
+
+- [ ] **Step 1: Write failing test for WebSocket auth**
+
+Add to `tests/test_auth_protected.py`:
+
+```python
+from starlette.testclient import TestClient as StarletteTestClient
+
+
+class TestWebSocketAuth:
+    """WebSocket connections require a valid token in the query string."""
+
+    def test_ws_no_token_rejected(self, protected_client):
+        with pytest.raises(Exception):
+            with protected_client.websocket_connect("/ws") as ws:
+                pass
+
+    def test_ws_invalid_token_rejected(self, protected_client):
+        with pytest.raises(Exception):
+            with protected_client.websocket_connect("/ws?token=garbage") as ws:
+                pass
+
+    def test_ws_valid_token_accepted(self, protected_client):
+        token = _token("user")
+        with protected_client.websocket_connect(f"/ws?token={token}") as ws:
+            data = ws.receive_json()
+            assert data["type"] == "connection_status"
+            assert data["status"] == "connected"
+
+    def test_ws_auth_disabled_no_token_accepted(self, isolated_app_client):
+        from web.app import app
+        app.state.auth_config = AuthConfig(enabled=False)
+        with isolated_app_client.websocket_connect("/ws") as ws:
+            data = ws.receive_json()
+            assert data["status"] == "connected"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth_protected.py::TestWebSocketAuth -v`
+Expected: FAIL — WebSocket accepts connections without token
+
+- [ ] **Step 3: Add token validation to WebSocket endpoint**
+
+In `web/app.py`, modify the `general_websocket_endpoint` function:
+
+```python
+from web.auth import decode_access_token
+
+@app.websocket("/ws")
+async def general_websocket_endpoint(websocket: WebSocket):
+    """General WebSocket endpoint for system-wide updates."""
+    auth_config = websocket.app.state.auth_config
+
+    if auth_config.enabled:
+        token = websocket.query_params.get("token")
+        if not token:
+            await websocket.close(code=4001, reason="Missing token")
+            return
+        try:
+            decode_access_token(token, auth_config.secret_key)
+        except Exception:
+            await websocket.close(code=4001, reason="Invalid token")
+            return
+
+    await websocket.accept()
+    try:
+        await websocket.send_text(json.dumps({
+            "type": "connection_status",
+            "status": "connected",
+            "message": "WebSocket connection established",
+            "service": "general"
+        }))
+
+        while True:
+            data = await websocket.receive_text()
+            await websocket.send_text(json.dumps({
+                "type": "connection_status",
+                "status": "connected",
+                "message": "WebSocket connection established"
+            }))
+    except WebSocketDisconnect:
+        pass
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth_protected.py::TestWebSocketAuth -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app.py tests/test_auth_protected.py
+git commit -m "feat(auth): add WebSocket token validation via query parameter for #87"
+```
+
+---
+
+> **Note — Per-user settings scoping:** The spec mentions user-scoped settings,
+> but the current settings system (`WebSettings`) is global. Filtering settings
+> by `user_id` requires changes to the settings service, settings API, and
+> frontend. This is deferred to a follow-up task after the core auth system is
+> stable. The `WorkWeekSettings` table already has a `user_id` column, so it
+> is partially prepared.
+
+---
+
+## Task 12: Final Validation
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/ -v --timeout=30`
+Expected: All tests pass. No regressions.
+
+- [ ] **Step 2: Verify all auth tests pass together**
+
+Run: `pyenv activate WorkJournal && python -m pytest tests/test_auth.py tests/test_auth_provider_local.py tests/test_auth_api.py tests/test_auth_protected.py tests/test_manage.py -v`
+Expected: All auth-related tests pass.
+
+- [ ] **Step 3: Verify CLI management tool runs**
+
+Run: `pyenv activate WorkJournal && python -m web.manage --help`
+Expected: Shows help with `create-admin` and `list-users` subcommands.
+
+- [ ] **Step 4: Review commit history**
+
+```bash
+git status
+git log --oneline feature/87-authentication ^main
+```
+
+Review the commit history to verify all tasks are represented.

--- a/docs/superpowers/sessions/session_auth-implementation_20260508_190611.md
+++ b/docs/superpowers/sessions/session_auth-implementation_20260508_190611.md
@@ -1,0 +1,99 @@
+# Session Summary: Authentication Implementation (Issue #87)
+
+**Date:** 2026-05-08
+**Branch:** `feature/87-authentication`
+**Duration:** ~1 session
+**Conversation turns:** ~30
+
+---
+
+## Key Actions
+
+### Planning Phase
+1. Switched to existing `feature/87-authentication` branch (design spec already committed from prior session)
+2. Read and analyzed the design spec (`docs/superpowers/specs/2026-05-08-authentication-design.md`)
+3. Examined codebase patterns: database.py, app.py, middleware.py, config_manager.py, conftest.py, existing routers
+4. Wrote 12-task TDD implementation plan (`docs/superpowers/plans/2026-05-08-authentication.md`)
+5. Self-reviewed plan against spec — found and fixed 3 gaps (WebSocket auth, per-user settings scoping, parameter naming)
+
+### Learning Exercise
+6. Conducted "Trace the Path" JWT token exercise (~10 min)
+   - User reported breakthrough: "I didn't understand JWT tokens until now"
+   - Key concepts landed: stateless validation, two-token design tradeoff, client-driven refresh, hash-as-defense-in-depth
+
+### Implementation Phase (Tasks 1-5 of 12)
+7. **Task 1:** Added PyJWT + bcrypt to requirements.txt
+8. **Task 2:** Added AuthConfig dataclass to config_manager.py
+   - Review caught: `WJM_` prefix should be `WJS_`, env var should use `env_mappings` dict, `save_example_config` needed update
+9. **Task 3:** Added UserAccount + RefreshToken ORM models to web/database.py
+   - Review caught: duplicate indexes (column `index=True` + standalone `Index()`)
+10. **Task 4:** Created web/auth.py with User, TokenPair, AuthProvider protocol, JWT encode/decode
+    - Review caught: overly broad `pytest.raises(Exception)`, forward-looking ABOUTME comment
+11. **Task 5:** Added get_current_user + require_admin FastAPI dependencies
+
+### Session Close
+12. Pushed branch, marked plan tasks 1-5 complete, saved journal entry
+
+---
+
+## Commits (11 total)
+
+| SHA | Message |
+|-----|---------|
+| 05607bc | docs: add authentication system design spec for #87 |
+| 70aa2f1 | docs: add authentication implementation plan for #87 |
+| ccb8b06 | feat(auth): add PyJWT and bcrypt dependencies for #87 |
+| c93d18e | feat(auth): add AuthConfig dataclass with env var override for #87 |
+| 934d68d | fix(auth): use WJS_ env var prefix and env_mappings dict for consistency |
+| 54e543a | feat(auth): add UserAccount and RefreshToken database models for #87 |
+| 2678e2f | fix(auth): remove duplicate indexes on columns that already have index=True |
+| c7fd927 | feat(auth): add User/TokenPair types, JWT encode/decode, AuthProvider protocol for #87 |
+| a3cc926 | fix(auth): use specific PyJWT exception types in tests, fix ABOUTME accuracy |
+| bd62ac3 | feat(auth): add get_current_user and require_admin FastAPI dependencies for #87 |
+| 076d802 | docs: mark tasks 1-5 complete in auth implementation plan |
+
+---
+
+## Tests Written
+
+- 17 tests in `tests/test_auth.py`, all passing
+- Covering: AuthConfig defaults, config loading, env var override, UserAccount CRUD, RefreshToken CRUD, User/TokenPair types, JWT encode/decode roundtrip, expired/invalid/wrong-secret tokens, get_current_user (valid/missing/invalid/disabled), require_admin (pass/reject)
+
+---
+
+## Efficiency Insights
+
+**What worked well:**
+- Subagent-driven development kept main context clean while executing TDD cycles
+- Two-stage review (spec + quality) caught 4 real issues across Tasks 2-4 that would have compounded later
+- Codebase exploration upfront (database.py, app.py, config_manager.py patterns) prevented subagent confusion
+- Haiku for reviews was cost-effective — caught real issues despite being the cheapest model
+
+**What could improve:**
+- Task 2 code quality review took ~465s (haiku) — disproportionate for a config dataclass. Could skip quality review for trivial tasks
+- The `WJS_` vs `WJM_` prefix issue could have been caught during plan writing if I'd checked the env_mappings convention before specifying the env var name in the plan
+- Design spec used `WJM_AUTH_SECRET_KEY` — plan should have corrected this before implementation
+
+---
+
+## Remaining Work (7 tasks)
+
+| Task | Description | Complexity |
+|------|-------------|------------|
+| 6 | LocalAuthProvider (web/providers/local.py) | Medium — bcrypt, refresh token rotation |
+| 7 | Auth API endpoints + wire into app.py | Medium — 4 endpoints, app startup changes |
+| 8 | Protect existing endpoints | Medium — touch 4 router files + conftest |
+| 9 | CLI management tool (web/manage.py) | Low — argparse + 2 async functions |
+| 10 | Add user_id to JournalEntryIndex | Low — one column addition |
+| 11 | WebSocket token validation | Low — query param check |
+| 12 | Final validation | Verification only |
+
+**Resume instructions:** Open new session on branch `feature/87-authentication`, read plan file, continue with Task 6 using subagent-driven development.
+
+---
+
+## Highlights
+
+- The JWT learning exercise was a genuine breakthrough moment for the user. The "stolen laptop" scenario for explaining the two-token design was particularly effective.
+- Code reviews caught the env var naming convention mismatch early — this would have been a confusing inconsistency in production.
+- The `AuthProvider` Protocol design enables future SSO providers without touching the auth dependency layer — a clean extension point.

--- a/docs/superpowers/specs/2026-05-08-authentication-design.md
+++ b/docs/superpowers/specs/2026-05-08-authentication-design.md
@@ -1,0 +1,207 @@
+# Authentication System Design
+
+**Date:** 2026-05-08
+**Issue:** #87 — No authentication on any web API endpoint
+**Approach:** FastAPI dependency injection with pluggable auth providers
+
+## Context
+
+The web application exposes 55+ API endpoints with zero authentication.
+Destructive operations (delete entries, reset settings, stop scheduler) are
+open to any network client. The application is transitioning from a
+single-user local tool to a shared-server deployment at LBNL, with desktop
+clients connecting to sync journal entries across machines.
+
+## Requirements
+
+1. **Pluggable auth providers** — swappable authentication backends. Local
+   username/password first, LBNL SSO (OIDC or SAML, TBD) later. Other orgs
+   can install and plug in their own provider.
+2. **Two roles** — `user` (manages own journals) and `admin` (manages system
+   settings, sync config, user accounts).
+3. **User-scoped data** — each user sees only their own journal entries and
+   per-user settings.
+4. **Desktop client auth** — browser redirect flow (standard OAuth pattern)
+   for desktop clients. Scoped to Cluster D, not implemented here.
+5. **Auth-optional mode** — configurable toggle so the app can run without
+   auth for local development and backward compatibility.
+
+## Architecture
+
+### Auth Provider Protocol
+
+```python
+class AuthProvider(Protocol):
+    async def authenticate(self, credentials: dict) -> TokenPair: ...
+    async def validate_token(self, token: str) -> User: ...
+    async def refresh_token(self, refresh_token: str) -> TokenPair: ...
+```
+
+Each provider implements this protocol. The active provider is selected by
+config and injected via FastAPI's dependency system.
+
+### User Model
+
+```python
+@dataclass
+class User:
+    id: str         # unique identifier from the provider
+    username: str   # display name
+    role: str       # "user" or "admin"
+```
+
+### Token Strategy
+
+- **Access token (JWT)** — 30-minute TTL, contains `user_id`, `username`,
+  `role`, `exp`. Sent as `Authorization: Bearer <token>` header. Stateless
+  validation via signature check.
+- **Refresh token** — 7-day TTL, stored hashed (SHA-256) in `refresh_tokens`
+  table. Revocable server-side. Used by desktop clients to maintain long
+  sessions without re-authenticating.
+
+### FastAPI Dependencies
+
+Two dependency functions enforce auth at the endpoint level:
+
+- `get_current_user` — extracts Bearer token from the `Authorization` header,
+  calls `provider.validate_token()`, returns `User` or raises HTTP 401.
+- `require_admin` — calls `get_current_user`, checks `role == "admin"`,
+  raises HTTP 403 if not.
+
+### Auth-Optional Mode
+
+When `auth.enabled` is `false` in config, `get_current_user` returns a default
+user (`id="default"`, `role="admin"`) without checking tokens. All existing
+behavior is preserved.
+
+## API Endpoints
+
+### New Auth Router (`/api/auth`)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/auth/login` | Public | Authenticate, receive token pair |
+| POST | `/api/auth/refresh` | Public | Exchange refresh token for new pair |
+| POST | `/api/auth/logout` | User | Revoke current refresh token |
+| GET | `/api/auth/me` | User | Current user profile |
+
+### Endpoint Classification
+
+| Category | Dependency | Examples |
+|----------|-----------|---------|
+| Public | None | `/api/auth/login`, `/api/auth/refresh`, `/api/health/` |
+| User | `get_current_user` | All entries, calendar, summarization endpoints |
+| Admin | `require_admin` | `settings/reset-all`, `settings/import`, `sync/scheduler/*`, `health/config`, `health/metrics` |
+
+### WebSocket Auth
+
+Tokens passed as query parameter (`?token=<jwt>`) on WebSocket connection URL,
+validated once at connection time. Standard workaround for the browser
+WebSocket API not supporting custom headers during handshake.
+
+## Database Changes
+
+### New Table: `users`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | String (UUID) | Primary key |
+| username | String | Unique, indexed |
+| password_hash | String | bcrypt hash |
+| role | String | "user" or "admin" |
+| is_active | Boolean | Soft-disable without deleting |
+| created_at | DateTime | Auto-set |
+| modified_at | DateTime | Auto-updated |
+
+Used by the local auth provider only. SSO providers will not use this table —
+they get user identity from the external IdP.
+
+### New Table: `refresh_tokens`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | String (UUID) | Primary key |
+| user_id | String | FK to users.id |
+| token_hash | String | SHA-256 of the raw token |
+| expires_at | DateTime | When this token expires |
+| revoked | Boolean | Set on logout or refresh |
+| created_at | DateTime | Auto-set |
+
+Raw refresh tokens are never stored — only their hash. This limits damage if
+the database is compromised.
+
+### Modified Table: `journal_entries`
+
+Add `user_id` column — nullable, default `"default"`. Existing entries retain
+the default value. New entries created by authenticated users get the real
+`user_id`. Queries filter by `user_id` when auth is enabled.
+
+## Configuration
+
+```yaml
+auth:
+  enabled: true          # false = open access (current behavior)
+  provider: local        # or "oidc", "saml" (future)
+  secret_key: "..."      # for JWT signing — must be set when enabled
+  access_token_ttl: 1800       # seconds (30 min)
+  refresh_token_ttl: 604800    # seconds (7 days)
+```
+
+The `secret_key` should be set via `WJM_AUTH_SECRET_KEY` environment variable
+in production. If `auth.enabled` is `true` and no secret key is configured,
+the application should refuse to start.
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `web/auth.py` | AuthProvider protocol, User/TokenPair models, JWT utilities, FastAPI dependencies |
+| `web/providers/local.py` | Local username/password provider (bcrypt + SQLite) |
+| `web/api/auth.py` | Auth API endpoints (login, refresh, logout, me) |
+| `web/manage.py` | CLI tool for user management (create-admin, list-users) |
+
+## CLI Management
+
+```bash
+python -m web.manage create-admin --username admin
+python -m web.manage list-users
+```
+
+The first admin must be created via CLI to avoid a chicken-and-egg problem
+where you can't create users through the API without being authenticated.
+
+## Migration Strategy
+
+**Phase 1: Auth-optional.** Deploy with `auth.enabled: false`. All existing
+tests pass without modification. Local development stays frictionless.
+
+**Phase 2: Enable auth.** Set `auth.enabled: true`, create an admin via CLI,
+start using tokens. Existing entries (with `user_id="default"`) remain
+accessible to all users — retroactive assignment is a future data migration.
+
+## Testing Strategy
+
+| Layer | What's tested | Approach |
+|-------|--------------|----------|
+| Provider unit tests | authenticate, validate_token, refresh_token | Direct calls, test DB, verify bcrypt/JWT behavior |
+| Dependency unit tests | get_current_user, require_admin | Valid/expired/missing tokens, role checks |
+| API integration tests | Auth endpoints | TestClient, full request/response cycle |
+| Protected endpoint tests | Existing endpoints with auth | 401 without token, 200 with token, 403 for admin-only |
+| Auth-disabled tests | auth.enabled=false mode | Verify existing behavior unchanged |
+| CLI tests | manage.py create-admin | User created with correct role and hashed password |
+
+All tests use isolation patterns from Clusters T1/T2.
+
+## Explicitly Out of Scope
+
+- SSO/OIDC/SAML provider implementation (blocked on LBNL protocol info)
+- Browser redirect OAuth flow for desktop client (Cluster D)
+- User self-registration UI (admin creates accounts via CLI)
+- Password reset flow (manageable via CLI for small user base)
+- Retroactive entry ownership migration (future, when multi-user deploys)
+
+## Dependencies
+
+- `PyJWT` — JWT encoding/decoding
+- `bcrypt` — password hashing
+- No new infrastructure dependencies (uses existing SQLite + FastAPI)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,7 @@ aiofiles>=23.0.0
 requests>=2.31.0
 psutil>=5.9.0
 pyinstaller>=6.0.0
+
+# Authentication
+PyJWT>=2.8.0
+bcrypt>=4.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,9 +67,19 @@ def isolated_app_client(tmp_path):
         orig_app_db = app.state.db_manager
         app.state.db_manager = temp_db
 
+        # Disable auth so existing tests work without tokens.
+        from config_manager import AuthConfig
+        orig_auth_config = getattr(app.state, 'auth_config', None)
+        orig_auth_provider = getattr(app.state, 'auth_provider', None)
+        app.state.auth_config = AuthConfig(enabled=False)
+        app.state.auth_provider = None
+
         yield client
 
         # Restore originals so the module-level singletons aren't permanently mutated
+        app.state.auth_config = orig_auth_config
+        app.state.auth_provider = orig_auth_provider
+
         em.file_discovery = orig_file_discovery
         em._current_base_path = orig_base_path
         em._settings_cache = orig_settings_cache

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -159,6 +159,79 @@ class TestJWTUtilities:
             decode_access_token(token, "wrong-secret")
 
 
+class TestGetCurrentUser:
+    """Tests for the get_current_user FastAPI dependency."""
+
+    SECRET = "test-secret-key-for-dependency-testing-32b"
+
+    def _make_request(self, token=None, enabled=True):
+        from unittest.mock import MagicMock
+        request = MagicMock()
+        request.app.state.auth_config = AuthConfig(enabled=enabled, secret_key=self.SECRET)
+        request.app.state.auth_provider = None
+        if token:
+            request.headers = {"authorization": f"Bearer {token}"}
+        else:
+            request.headers = {}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_user(self):
+        from web.auth import User, encode_access_token, get_current_user
+        user = User(id="u1", username="alice", role="user")
+        token = encode_access_token(user, self.SECRET, ttl_seconds=300)
+        request = self._make_request(token)
+        result = await get_current_user(request)
+        assert result.id == "u1"
+        assert result.username == "alice"
+
+    @pytest.mark.asyncio
+    async def test_missing_header_raises_401(self):
+        from fastapi import HTTPException
+        from web.auth import get_current_user
+        request = self._make_request(token=None)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(request)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_raises_401(self):
+        from fastapi import HTTPException
+        from web.auth import get_current_user
+        request = self._make_request(token="garbage.token.here")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(request)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_auth_disabled_returns_default_admin(self):
+        from web.auth import get_current_user
+        request = self._make_request(enabled=False)
+        result = await get_current_user(request)
+        assert result.id == "default"
+        assert result.role == "admin"
+
+
+class TestRequireAdmin:
+    """Tests for the require_admin FastAPI dependency."""
+
+    @pytest.mark.asyncio
+    async def test_admin_user_passes(self):
+        from web.auth import User, require_admin
+        user = User(id="u1", username="admin", role="admin")
+        result = await require_admin(user)
+        assert result.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_non_admin_raises_403(self):
+        from fastapi import HTTPException
+        from web.auth import User, require_admin
+        user = User(id="u2", username="viewer", role="user")
+        with pytest.raises(HTTPException) as exc_info:
+            await require_admin(user)
+        assert exc_info.value.status_code == 403
+
+
 class TestAuthConfigLoading:
     """Tests for loading auth config from files and environment."""
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -125,7 +125,7 @@ class TestAuthTypes:
 class TestJWTUtilities:
     """Tests for JWT token encoding and decoding."""
 
-    SECRET = "test-secret-key-for-jwt-testing"
+    SECRET = "test-secret-key-for-jwt-testing!!"
 
     def test_encode_decode_roundtrip(self):
         from web.auth import User, encode_access_token, decode_access_token

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -204,6 +204,18 @@ class TestGetCurrentUser:
         assert exc_info.value.status_code == 401
 
     @pytest.mark.asyncio
+    async def test_expired_token_raises_401(self):
+        from fastapi import HTTPException
+        from web.auth import User, encode_access_token, get_current_user
+        user = User(id="u1", username="alice", role="user")
+        token = encode_access_token(user, self.SECRET, ttl_seconds=-1)
+        request = self._make_request(token)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(request)
+        assert exc_info.value.status_code == 401
+        assert "expired" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
     async def test_auth_disabled_returns_default_admin(self):
         from web.auth import get_current_user
         request = self._make_request(enabled=False)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -104,6 +104,58 @@ class TestAuthDatabaseModels:
         loop.close()
 
 
+class TestAuthTypes:
+    """Tests for User and TokenPair dataclasses."""
+
+    def test_user_creation(self):
+        from web.auth import User
+        user = User(id="u1", username="alice", role="user")
+        assert user.id == "u1"
+        assert user.username == "alice"
+        assert user.role == "user"
+
+    def test_token_pair_creation(self):
+        from web.auth import TokenPair
+        pair = TokenPair(access_token="acc", refresh_token="ref")
+        assert pair.access_token == "acc"
+        assert pair.refresh_token == "ref"
+
+
+class TestJWTUtilities:
+    """Tests for JWT token encoding and decoding."""
+
+    SECRET = "test-secret-key-for-jwt-testing"
+
+    def test_encode_decode_roundtrip(self):
+        from web.auth import User, encode_access_token, decode_access_token
+        user = User(id="u1", username="alice", role="user")
+        token = encode_access_token(user, self.SECRET, ttl_seconds=300)
+        decoded = decode_access_token(token, self.SECRET)
+        assert decoded["user_id"] == "u1"
+        assert decoded["username"] == "alice"
+        assert decoded["role"] == "user"
+        assert "exp" in decoded
+
+    def test_decode_expired_token_raises(self):
+        from web.auth import User, encode_access_token, decode_access_token
+        user = User(id="u1", username="alice", role="user")
+        token = encode_access_token(user, self.SECRET, ttl_seconds=-1)
+        with pytest.raises(Exception):
+            decode_access_token(token, self.SECRET)
+
+    def test_decode_invalid_token_raises(self):
+        from web.auth import decode_access_token
+        with pytest.raises(Exception):
+            decode_access_token("not.a.valid.token", self.SECRET)
+
+    def test_decode_wrong_secret_raises(self):
+        from web.auth import User, encode_access_token, decode_access_token
+        user = User(id="u1", username="alice", role="user")
+        token = encode_access_token(user, self.SECRET, ttl_seconds=300)
+        with pytest.raises(Exception):
+            decode_access_token(token, "wrong-secret")
+
+
 class TestAuthConfigLoading:
     """Tests for loading auth config from files and environment."""
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,37 @@
+# ABOUTME: Unit tests for auth configuration, JWT utilities, and FastAPI dependencies.
+# ABOUTME: Validates auth-disabled mode, token lifecycle, and role-based access control.
+
+import os
+import pytest
+from unittest.mock import patch
+from config_manager import AppConfig, AuthConfig, ConfigManager
+
+
+class TestAuthConfig:
+    """Tests for AuthConfig dataclass and its integration with AppConfig."""
+
+    def test_auth_config_defaults(self):
+        config = AuthConfig()
+        assert config.enabled is False
+        assert config.provider == "local"
+        assert config.secret_key == ""
+        assert config.access_token_ttl == 1800
+        assert config.refresh_token_ttl == 604800
+
+    def test_app_config_includes_auth(self):
+        config = AppConfig()
+        assert hasattr(config, "auth")
+        assert isinstance(config.auth, AuthConfig)
+        assert config.auth.enabled is False
+
+
+class TestAuthConfigLoading:
+    """Tests for loading auth config from files and environment."""
+
+    def test_secret_key_from_env_var(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("auth:\n  enabled: true\n")
+        with patch.dict(os.environ, {"WJM_AUTH_SECRET_KEY": "test-secret-key-12345"}):
+            manager = ConfigManager(config_path=config_file)
+            assert manager.config.auth.secret_key == "test-secret-key-12345"
+            assert manager.config.auth.enabled is True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -137,22 +137,25 @@ class TestJWTUtilities:
         assert "exp" in decoded
 
     def test_decode_expired_token_raises(self):
+        import jwt as pyjwt
         from web.auth import User, encode_access_token, decode_access_token
         user = User(id="u1", username="alice", role="user")
         token = encode_access_token(user, self.SECRET, ttl_seconds=-1)
-        with pytest.raises(Exception):
+        with pytest.raises(pyjwt.ExpiredSignatureError):
             decode_access_token(token, self.SECRET)
 
     def test_decode_invalid_token_raises(self):
+        import jwt as pyjwt
         from web.auth import decode_access_token
-        with pytest.raises(Exception):
+        with pytest.raises(pyjwt.DecodeError):
             decode_access_token("not.a.valid.token", self.SECRET)
 
     def test_decode_wrong_secret_raises(self):
+        import jwt as pyjwt
         from web.auth import User, encode_access_token, decode_access_token
         user = User(id="u1", username="alice", role="user")
         token = encode_access_token(user, self.SECRET, ttl_seconds=300)
-        with pytest.raises(Exception):
+        with pytest.raises(pyjwt.InvalidSignatureError):
             decode_access_token(token, "wrong-secret")
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,12 @@
 # ABOUTME: Unit tests for auth configuration, JWT utilities, and FastAPI dependencies.
 # ABOUTME: Validates auth-disabled mode, token lifecycle, and role-based access control.
 
+import asyncio
 import os
 import pytest
 from unittest.mock import patch
 from config_manager import AppConfig, AuthConfig, ConfigManager
+from web.database import DatabaseManager, UserAccount, RefreshToken
 
 
 class TestAuthConfig:
@@ -23,6 +25,83 @@ class TestAuthConfig:
         assert hasattr(config, "auth")
         assert isinstance(config.auth, AuthConfig)
         assert config.auth.enabled is False
+
+
+class TestAuthDatabaseModels:
+    """Tests for auth-related database models."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_auth.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    def test_create_user_account(self, db):
+        from sqlalchemy import select
+        import uuid
+
+        async def _test():
+            async with db.get_session() as session:
+                user = UserAccount(
+                    id=str(uuid.uuid4()),
+                    username="testadmin",
+                    password_hash="$2b$12$fakehash",
+                    role="admin",
+                    is_active=True,
+                )
+                session.add(user)
+                await session.commit()
+
+                stmt = select(UserAccount).where(UserAccount.username == "testadmin")
+                result = await session.execute(stmt)
+                found = result.scalar_one()
+                assert found.username == "testadmin"
+                assert found.role == "admin"
+                assert found.is_active is True
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_create_refresh_token(self, db):
+        from sqlalchemy import select
+        import uuid
+        from datetime import datetime, timedelta, timezone
+
+        async def _test():
+            async with db.get_session() as session:
+                user_id = str(uuid.uuid4())
+                user = UserAccount(
+                    id=user_id,
+                    username="tokenuser",
+                    password_hash="$2b$12$fakehash",
+                    role="user",
+                )
+                session.add(user)
+                await session.commit()
+
+                token = RefreshToken(
+                    id=str(uuid.uuid4()),
+                    user_id=user_id,
+                    token_hash="sha256hashvalue",
+                    expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+                )
+                session.add(token)
+                await session.commit()
+
+                stmt = select(RefreshToken).where(RefreshToken.user_id == user_id)
+                result = await session.execute(stmt)
+                found = result.scalar_one()
+                assert found.token_hash == "sha256hashvalue"
+                assert found.revoked is False
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
 
 
 class TestAuthConfigLoading:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,8 @@ import os
 import pytest
 from unittest.mock import patch
 from config_manager import AppConfig, AuthConfig, ConfigManager
-from web.database import DatabaseManager, UserAccount, RefreshToken
+from datetime import date
+from web.database import DatabaseManager, JournalEntryIndex, UserAccount, RefreshToken
 
 
 class TestAuthConfig:
@@ -254,3 +255,44 @@ class TestAuthConfigLoading:
             manager = ConfigManager(config_path=config_file)
             assert manager.config.auth.secret_key == "test-secret-key-12345"
             assert manager.config.auth.enabled is True
+
+
+class TestJournalEntryUserScoping:
+    """Tests for user_id column on journal entries."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_scoping.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    def test_entry_has_user_id_column(self):
+        assert hasattr(JournalEntryIndex, "user_id")
+
+    def test_entry_default_user_id(self, db):
+        from sqlalchemy import select
+
+        async def _test():
+            async with db.get_session() as session:
+                entry = JournalEntryIndex(
+                    date=date(2026, 5, 1),
+                    file_path="/tmp/test.txt",
+                    week_ending_date=date(2026, 5, 2),
+                )
+                session.add(entry)
+                await session.commit()
+
+                stmt = select(JournalEntryIndex).where(
+                    JournalEntryIndex.date == date(2026, 5, 1)
+                )
+                result = await session.execute(stmt)
+                found = result.scalar_one()
+                assert found.user_id == "default"
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -31,7 +31,7 @@ class TestAuthConfigLoading:
     def test_secret_key_from_env_var(self, tmp_path):
         config_file = tmp_path / "config.yaml"
         config_file.write_text("auth:\n  enabled: true\n")
-        with patch.dict(os.environ, {"WJM_AUTH_SECRET_KEY": "test-secret-key-12345"}):
+        with patch.dict(os.environ, {"WJS_AUTH_SECRET_KEY": "test-secret-key-12345"}):
             manager = ConfigManager(config_path=config_file)
             assert manager.config.auth.secret_key == "test-secret-key-12345"
             assert manager.config.auth.enabled is True

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -1,0 +1,162 @@
+# ABOUTME: Integration tests for the /api/auth endpoints.
+# ABOUTME: Tests login, refresh, logout, and profile using TestClient.
+
+import asyncio
+import time
+import uuid
+import pytest
+import bcrypt
+from fastapi.testclient import TestClient
+
+from web.app import app
+from web.database import DatabaseManager, UserAccount
+from config_manager import AuthConfig
+
+
+@pytest.fixture
+def auth_client(tmp_path):
+    """TestClient with auth enabled and a seeded admin user."""
+    secret = "integration-test-secret-key"
+
+    with TestClient(app) as client:
+        # Set up auth config on app state
+        auth_config = AuthConfig(enabled=True, secret_key=secret)
+        app.state.auth_config = auth_config
+
+        # Set up temp DB
+        db = DatabaseManager(str(tmp_path / "test_auth_api.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+
+        # Seed an admin user
+        pw_hash = bcrypt.hashpw(b"admin-pass", bcrypt.gensalt()).decode()
+        user_id = str(uuid.uuid4())
+
+        async def _seed():
+            async with db.get_session() as session:
+                session.add(UserAccount(
+                    id=user_id,
+                    username="admin",
+                    password_hash=pw_hash,
+                    role="admin",
+                ))
+                await session.commit()
+
+        loop.run_until_complete(_seed())
+
+        # Initialize the local provider
+        from web.providers.local import LocalAuthProvider
+        provider = LocalAuthProvider(db, auth_config)
+        app.state.auth_provider = provider
+
+        yield client
+
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+
+class TestAuthLogin:
+    """Tests for POST /api/auth/login."""
+
+    def test_login_success(self, auth_client):
+        resp = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "admin-pass",
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "access_token" in body
+        assert "refresh_token" in body
+
+    def test_login_wrong_password(self, auth_client):
+        resp = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "wrong",
+        })
+        assert resp.status_code == 401
+
+    def test_login_unknown_user(self, auth_client):
+        resp = auth_client.post("/api/auth/login", json={
+            "username": "nobody",
+            "password": "anything",
+        })
+        assert resp.status_code == 401
+
+
+class TestAuthRefresh:
+    """Tests for POST /api/auth/refresh."""
+
+    def test_refresh_success(self, auth_client):
+        login = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "admin-pass",
+        })
+        refresh_token = login.json()["refresh_token"]
+
+        # Sleep 1 second so the new access token has a different iat/exp
+        time.sleep(1)
+
+        resp = auth_client.post("/api/auth/refresh", json={
+            "refresh_token": refresh_token,
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "access_token" in body
+        assert body["access_token"] != login.json()["access_token"]
+
+    def test_refresh_invalid_token(self, auth_client):
+        resp = auth_client.post("/api/auth/refresh", json={
+            "refresh_token": "not-a-real-token",
+        })
+        assert resp.status_code == 401
+
+
+class TestAuthLogout:
+    """Tests for POST /api/auth/logout."""
+
+    def test_logout_revokes_refresh_token(self, auth_client):
+        login = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "admin-pass",
+        })
+        tokens = login.json()
+        access = tokens["access_token"]
+        refresh = tokens["refresh_token"]
+
+        resp = auth_client.post(
+            "/api/auth/logout",
+            json={"refresh_token": refresh},
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert resp.status_code == 200
+
+        # Refresh token should now be invalid
+        resp = auth_client.post("/api/auth/refresh", json={
+            "refresh_token": refresh,
+        })
+        assert resp.status_code == 401
+
+
+class TestAuthMe:
+    """Tests for GET /api/auth/me."""
+
+    def test_me_returns_profile(self, auth_client):
+        login = auth_client.post("/api/auth/login", json={
+            "username": "admin",
+            "password": "admin-pass",
+        })
+        access = login.json()["access_token"]
+
+        resp = auth_client.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["username"] == "admin"
+        assert body["role"] == "admin"
+
+    def test_me_without_token_returns_401(self, auth_client):
+        resp = auth_client.get("/api/auth/me")
+        assert resp.status_code == 401

--- a/tests/test_auth_protected.py
+++ b/tests/test_auth_protected.py
@@ -1,0 +1,144 @@
+# ABOUTME: Tests that existing endpoints enforce authentication correctly.
+# ABOUTME: Validates 401 without token, 200 with token, and 403 for admin-only routes.
+
+import asyncio
+import pytest
+from fastapi.testclient import TestClient
+
+from web.app import app
+from web.database import DatabaseManager
+from config_manager import AuthConfig
+from web.auth import User, encode_access_token
+
+
+SECRET = "protected-endpoint-test-secret"
+
+
+@pytest.fixture
+def protected_client(tmp_path):
+    """TestClient with auth ENABLED."""
+    with TestClient(app) as client:
+        auth_config = AuthConfig(enabled=True, secret_key=SECRET)
+        app.state.auth_config = auth_config
+        app.state.auth_provider = None
+
+        # Swap to temp DB
+        db = DatabaseManager(str(tmp_path / "test_protected.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+
+        orig_db = app.state.db_manager
+        app.state.db_manager = db
+        for name, svc in app.state._state.items():
+            if name not in ('db_manager', 'auth_config', 'auth_provider') and hasattr(svc, 'db_manager'):
+                svc.db_manager = db
+
+        yield client
+
+        app.state.db_manager = orig_db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+
+def _token(role="user"):
+    user = User(id="u1", username="tester", role=role)
+    return encode_access_token(user, SECRET, ttl_seconds=300)
+
+
+class TestEntriesAuth:
+    """Entries endpoints require user-level auth."""
+
+    def test_list_entries_no_token_401(self, protected_client):
+        resp = protected_client.get("/api/entries/")
+        assert resp.status_code == 401
+
+    def test_list_entries_with_token_200(self, protected_client):
+        resp = protected_client.get(
+            "/api/entries/",
+            headers={"Authorization": f"Bearer {_token()}"},
+        )
+        assert resp.status_code == 200
+
+
+class TestSettingsAuth:
+    """Settings endpoints enforce appropriate auth levels."""
+
+    def test_get_settings_no_token_401(self, protected_client):
+        resp = protected_client.get("/api/settings/")
+        assert resp.status_code == 401
+
+    def test_get_settings_with_token_200(self, protected_client):
+        resp = protected_client.get(
+            "/api/settings/",
+            headers={"Authorization": f"Bearer {_token()}"},
+        )
+        assert resp.status_code == 200
+
+    def test_reset_all_no_token_401(self, protected_client):
+        resp = protected_client.post("/api/settings/reset-all")
+        assert resp.status_code == 401
+
+    def test_reset_all_user_role_403(self, protected_client):
+        resp = protected_client.post(
+            "/api/settings/reset-all",
+            headers={"Authorization": f"Bearer {_token('user')}"},
+        )
+        assert resp.status_code == 403
+
+    def test_reset_all_admin_role_allowed(self, protected_client):
+        resp = protected_client.post(
+            "/api/settings/reset-all",
+            headers={"Authorization": f"Bearer {_token('admin')}"},
+        )
+        # Should not be 401 or 403
+        assert resp.status_code not in (401, 403)
+
+
+class TestSyncAuth:
+    """Sync endpoints require admin auth for state changes."""
+
+    def test_sync_status_no_token_401(self, protected_client):
+        resp = protected_client.get("/api/sync/status")
+        assert resp.status_code == 401
+
+    def test_full_sync_no_token_401(self, protected_client):
+        resp = protected_client.post("/api/sync/full")
+        assert resp.status_code == 401
+
+    def test_full_sync_user_role_403(self, protected_client):
+        resp = protected_client.post(
+            "/api/sync/full",
+            headers={"Authorization": f"Bearer {_token('user')}"},
+        )
+        assert resp.status_code == 403
+
+
+class TestHealthAuth:
+    """Health endpoint is public; /config and /metrics require admin."""
+
+    def test_health_public(self, protected_client):
+        resp = protected_client.get("/api/health/")
+        assert resp.status_code == 200
+
+    def test_config_no_token_401(self, protected_client):
+        resp = protected_client.get("/api/health/config")
+        assert resp.status_code == 401
+
+    def test_metrics_no_token_401(self, protected_client):
+        resp = protected_client.get("/api/health/metrics")
+        assert resp.status_code == 401
+
+
+class TestAuthDisabled:
+    """When auth is disabled, all endpoints work without tokens."""
+
+    def test_entries_accessible(self, isolated_app_client):
+        app.state.auth_config = AuthConfig(enabled=False)
+        resp = isolated_app_client.get("/api/entries/")
+        assert resp.status_code == 200
+
+    def test_settings_accessible(self, isolated_app_client):
+        app.state.auth_config = AuthConfig(enabled=False)
+        resp = isolated_app_client.get("/api/settings/")
+        assert resp.status_code == 200

--- a/tests/test_auth_protected.py
+++ b/tests/test_auth_protected.py
@@ -199,3 +199,32 @@ class TestSummarizationAuth:
             headers={"Authorization": f"Bearer {_token('user')}"},
         )
         assert resp.status_code == 403
+
+
+class TestWebSocketAuth:
+    """WebSocket connections require a valid token in the query string."""
+
+    def test_ws_no_token_rejected(self, protected_client):
+        with pytest.raises(Exception):
+            with protected_client.websocket_connect("/ws") as ws:
+                pass
+
+    def test_ws_invalid_token_rejected(self, protected_client):
+        with pytest.raises(Exception):
+            with protected_client.websocket_connect("/ws?token=garbage") as ws:
+                pass
+
+    def test_ws_valid_token_accepted(self, protected_client):
+        token = _token("user")
+        with protected_client.websocket_connect(f"/ws?token={token}") as ws:
+            data = ws.receive_json()
+            assert data["type"] == "connection_status"
+            assert data["status"] == "connected"
+
+    def test_ws_auth_disabled_no_token_accepted(self, isolated_app_client):
+        from web.app import app
+        from config_manager import AuthConfig
+        app.state.auth_config = AuthConfig(enabled=False)
+        with isolated_app_client.websocket_connect("/ws") as ws:
+            data = ws.receive_json()
+            assert data["status"] == "connected"

--- a/tests/test_auth_protected.py
+++ b/tests/test_auth_protected.py
@@ -11,13 +11,16 @@ from config_manager import AuthConfig
 from web.auth import User, encode_access_token
 
 
-SECRET = "protected-endpoint-test-secret"
+SECRET = "protected-endpoint-test-secret!!"
 
 
 @pytest.fixture
 def protected_client(tmp_path):
     """TestClient with auth ENABLED."""
     with TestClient(app) as client:
+        orig_auth_config = getattr(app.state, 'auth_config', None)
+        orig_auth_provider = getattr(app.state, 'auth_provider', None)
+
         auth_config = AuthConfig(enabled=True, secret_key=SECRET)
         app.state.auth_config = auth_config
         app.state.auth_provider = None
@@ -35,6 +38,8 @@ def protected_client(tmp_path):
 
         yield client
 
+        app.state.auth_config = orig_auth_config
+        app.state.auth_provider = orig_auth_provider
         app.state.db_manager = orig_db
         if db.engine:
             loop.run_until_complete(db.engine.dispose())
@@ -59,6 +64,13 @@ class TestEntriesAuth:
             headers={"Authorization": f"Bearer {_token()}"},
         )
         assert resp.status_code == 200
+
+    def test_delete_entry_user_role_403(self, protected_client):
+        resp = protected_client.delete(
+            "/api/entries/2026-01-01",
+            headers={"Authorization": f"Bearer {_token('user')}"},
+        )
+        assert resp.status_code == 403
 
 
 class TestSettingsAuth:
@@ -142,3 +154,48 @@ class TestAuthDisabled:
         app.state.auth_config = AuthConfig(enabled=False)
         resp = isolated_app_client.get("/api/settings/")
         assert resp.status_code == 200
+
+
+class TestCalendarAuth:
+    """Calendar endpoints require user-level auth."""
+
+    def test_today_no_token_401(self, protected_client):
+        resp = protected_client.get("/api/calendar/today")
+        assert resp.status_code == 401
+
+    def test_today_with_token_200(self, protected_client):
+        resp = protected_client.get(
+            "/api/calendar/today",
+            headers={"Authorization": f"Bearer {_token()}"},
+        )
+        assert resp.status_code == 200
+
+
+class TestSummarizationAuth:
+    """Summarization endpoints enforce appropriate auth levels."""
+
+    def test_get_tasks_no_token_401(self, protected_client):
+        resp = protected_client.get("/api/summarization/tasks")
+        assert resp.status_code == 401
+
+    def test_get_tasks_with_token_200(self, protected_client):
+        resp = protected_client.get(
+            "/api/summarization/tasks",
+            headers={"Authorization": f"Bearer {_token()}"},
+        )
+        assert resp.status_code == 200
+
+    def test_create_task_user_role_403(self, protected_client):
+        resp = protected_client.post(
+            "/api/summarization/tasks",
+            json={"summary_type": "weekly", "start_date": "2026-01-01", "end_date": "2026-01-07"},
+            headers={"Authorization": f"Bearer {_token('user')}"},
+        )
+        assert resp.status_code == 403
+
+    def test_cleanup_user_role_403(self, protected_client):
+        resp = protected_client.post(
+            "/api/summarization/cleanup",
+            headers={"Authorization": f"Bearer {_token('user')}"},
+        )
+        assert resp.status_code == 403

--- a/tests/test_auth_provider_local.py
+++ b/tests/test_auth_provider_local.py
@@ -1,0 +1,174 @@
+# ABOUTME: Tests for the local username/password authentication provider.
+# ABOUTME: Validates password hashing, token issuance, refresh, and revocation.
+
+import asyncio
+import uuid
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from web.database import DatabaseManager, UserAccount
+from web.providers.local import LocalAuthProvider
+from web.auth import User, TokenPair, decode_access_token
+from config_manager import AuthConfig
+
+
+class TestLocalAuthProvider:
+    """Tests for LocalAuthProvider."""
+
+    SECRET = "test-secret-for-local-provider"
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_local_auth.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    @pytest.fixture
+    def config(self):
+        return AuthConfig(
+            enabled=True,
+            secret_key=self.SECRET,
+            access_token_ttl=300,
+            refresh_token_ttl=86400,
+        )
+
+    @pytest.fixture
+    def provider(self, db, config):
+        return LocalAuthProvider(db, config)
+
+    @pytest.fixture
+    def seeded_user(self, provider):
+        """Create a test user via the provider's hash utility."""
+        import bcrypt
+
+        async def _seed(db):
+            pw_hash = bcrypt.hashpw(b"correct-password", bcrypt.gensalt()).decode()
+            user_id = str(uuid.uuid4())
+            async with db.get_session() as session:
+                session.add(UserAccount(
+                    id=user_id,
+                    username="testuser",
+                    password_hash=pw_hash,
+                    role="user",
+                ))
+                await session.commit()
+            return user_id
+
+        loop = asyncio.new_event_loop()
+        user_id = loop.run_until_complete(_seed(provider.db))
+        loop.close()
+        return user_id
+
+    def test_authenticate_success(self, provider, seeded_user):
+        async def _test():
+            pair = await provider.authenticate({
+                "username": "testuser",
+                "password": "correct-password",
+            })
+            assert isinstance(pair, TokenPair)
+            assert pair.access_token
+            assert pair.refresh_token
+            payload = decode_access_token(pair.access_token, self.SECRET)
+            assert payload["username"] == "testuser"
+            assert payload["role"] == "user"
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_authenticate_wrong_password(self, provider, seeded_user):
+        async def _test():
+            with pytest.raises(Exception):
+                await provider.authenticate({
+                    "username": "testuser",
+                    "password": "wrong-password",
+                })
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_authenticate_unknown_user(self, provider):
+        async def _test():
+            with pytest.raises(Exception):
+                await provider.authenticate({
+                    "username": "nonexistent",
+                    "password": "anything",
+                })
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_authenticate_inactive_user(self, provider, db):
+        import bcrypt
+
+        async def _test():
+            pw_hash = bcrypt.hashpw(b"pass", bcrypt.gensalt()).decode()
+            async with db.get_session() as session:
+                session.add(UserAccount(
+                    id=str(uuid.uuid4()),
+                    username="inactive",
+                    password_hash=pw_hash,
+                    role="user",
+                    is_active=False,
+                ))
+                await session.commit()
+
+            with pytest.raises(Exception):
+                await provider.authenticate({
+                    "username": "inactive",
+                    "password": "pass",
+                })
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_validate_token(self, provider, seeded_user):
+        async def _test():
+            pair = await provider.authenticate({
+                "username": "testuser",
+                "password": "correct-password",
+            })
+            user = await provider.validate_token(pair.access_token)
+            assert user.username == "testuser"
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_refresh_token_success(self, provider, seeded_user):
+        async def _test():
+            import asyncio as _asyncio
+            pair = await provider.authenticate({
+                "username": "testuser",
+                "password": "correct-password",
+            })
+            # Wait 1 second so the new token's iat differs (PyJWT uses integer seconds).
+            await _asyncio.sleep(1)
+            new_pair = await provider.refresh_token(pair.refresh_token)
+            assert isinstance(new_pair, TokenPair)
+            assert new_pair.access_token != pair.access_token
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_revoke_token(self, provider, seeded_user):
+        async def _test():
+            pair = await provider.authenticate({
+                "username": "testuser",
+                "password": "correct-password",
+            })
+            await provider.revoke_token(pair.refresh_token)
+            with pytest.raises(Exception):
+                await provider.refresh_token(pair.refresh_token)
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()

--- a/tests/test_auth_provider_local.py
+++ b/tests/test_auth_provider_local.py
@@ -5,9 +5,10 @@ import asyncio
 import uuid
 import pytest
 from datetime import datetime, timedelta, timezone
+from sqlalchemy import select
 
-from web.database import DatabaseManager, UserAccount
-from web.providers.local import LocalAuthProvider
+from web.database import DatabaseManager, UserAccount, RefreshToken
+from web.providers.local import LocalAuthProvider, AuthenticationError
 from web.auth import User, TokenPair, decode_access_token
 from config_manager import AuthConfig
 
@@ -82,7 +83,7 @@ class TestLocalAuthProvider:
 
     def test_authenticate_wrong_password(self, provider, seeded_user):
         async def _test():
-            with pytest.raises(Exception):
+            with pytest.raises(AuthenticationError):
                 await provider.authenticate({
                     "username": "testuser",
                     "password": "wrong-password",
@@ -94,7 +95,7 @@ class TestLocalAuthProvider:
 
     def test_authenticate_unknown_user(self, provider):
         async def _test():
-            with pytest.raises(Exception):
+            with pytest.raises(AuthenticationError):
                 await provider.authenticate({
                     "username": "nonexistent",
                     "password": "anything",
@@ -119,7 +120,7 @@ class TestLocalAuthProvider:
                 ))
                 await session.commit()
 
-            with pytest.raises(Exception):
+            with pytest.raises(AuthenticationError):
                 await provider.authenticate({
                     "username": "inactive",
                     "password": "pass",
@@ -166,7 +167,30 @@ class TestLocalAuthProvider:
                 "password": "correct-password",
             })
             await provider.revoke_token(pair.refresh_token)
-            with pytest.raises(Exception):
+            with pytest.raises(AuthenticationError):
+                await provider.refresh_token(pair.refresh_token)
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_refresh_expired_token(self, provider, db, seeded_user):
+        async def _test():
+            pair = await provider.authenticate({
+                "username": "testuser",
+                "password": "correct-password",
+            })
+
+            # Back-date the stored refresh token so it appears expired.
+            token_hash = provider._hash_refresh_token(pair.refresh_token)
+            async with db.get_session() as session:
+                stmt = select(RefreshToken).where(RefreshToken.token_hash == token_hash)
+                result = await session.execute(stmt)
+                stored = result.scalar_one()
+                stored.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+                await session.commit()
+
+            with pytest.raises(AuthenticationError):
                 await provider.refresh_token(pair.refresh_token)
 
         loop = asyncio.new_event_loop()

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -45,7 +45,7 @@ class TestCreateAdmin:
     def test_create_duplicate_username_raises(self, db):
         async def _test():
             await create_admin(db, "dup", "pass1")
-            with pytest.raises(Exception):
+            with pytest.raises(ValueError):
                 await create_admin(db, "dup", "pass2")
 
         loop = asyncio.new_event_loop()

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -1,0 +1,89 @@
+# ABOUTME: Tests for the CLI user management tool (create-admin, list-users).
+# ABOUTME: Validates user creation with proper password hashing and role assignment.
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+from io import StringIO
+
+from web.database import DatabaseManager, UserAccount
+from web.manage import create_admin, list_users
+
+
+class TestCreateAdmin:
+    """Tests for the create-admin CLI command."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_manage.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    def test_create_admin_user(self, db):
+        import bcrypt
+        from sqlalchemy import select
+
+        async def _test():
+            await create_admin(db, "myadmin", "securepass123")
+
+            async with db.get_session() as session:
+                stmt = select(UserAccount).where(UserAccount.username == "myadmin")
+                result = await session.execute(stmt)
+                user = result.scalar_one()
+                assert user.role == "admin"
+                assert user.is_active is True
+                assert bcrypt.checkpw(b"securepass123", user.password_hash.encode())
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_create_duplicate_username_raises(self, db):
+        async def _test():
+            await create_admin(db, "dup", "pass1")
+            with pytest.raises(Exception):
+                await create_admin(db, "dup", "pass2")
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+
+class TestListUsers:
+    """Tests for the list-users CLI command."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        db = DatabaseManager(str(tmp_path / "test_manage_list.db"))
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(db.initialize())
+        yield db
+        if db.engine:
+            loop.run_until_complete(db.engine.dispose())
+        loop.close()
+
+    def test_list_empty(self, db):
+        async def _test():
+            users = await list_users(db)
+            assert users == []
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()
+
+    def test_list_after_create(self, db):
+        async def _test():
+            await create_admin(db, "admin1", "pass")
+            users = await list_users(db)
+            assert len(users) == 1
+            assert users[0]["username"] == "admin1"
+            assert users[0]["role"] == "admin"
+            assert "password_hash" not in users[0]
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_test())
+        loop.close()

--- a/web/api/auth.py
+++ b/web/api/auth.py
@@ -37,6 +37,11 @@ class UserProfile(BaseModel):
 async def login(body: LoginRequest, request: Request):
     """Authenticate with username/password and receive a token pair."""
     provider = request.app.state.auth_provider
+    if provider is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication is not configured",
+        )
     try:
         pair = await provider.authenticate({
             "username": body.username,
@@ -54,6 +59,11 @@ async def login(body: LoginRequest, request: Request):
 async def refresh(body: RefreshRequest, request: Request):
     """Exchange a refresh token for a new token pair."""
     provider = request.app.state.auth_provider
+    if provider is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication is not configured",
+        )
     try:
         pair = await provider.refresh_token(body.refresh_token)
     except Exception:
@@ -72,6 +82,11 @@ async def logout(
 ):
     """Revoke a refresh token (logout)."""
     provider = request.app.state.auth_provider
+    if provider is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication is not configured",
+        )
     await provider.revoke_token(body.refresh_token)
     return {"detail": "Logged out"}
 

--- a/web/api/auth.py
+++ b/web/api/auth.py
@@ -1,0 +1,82 @@
+# ABOUTME: REST API endpoints for authentication (login, refresh, logout, profile).
+# ABOUTME: Delegates to the active AuthProvider via app.state.
+
+from fastapi import APIRouter, HTTPException, Request, Depends, status
+from pydantic import BaseModel
+
+from web.auth import get_current_user, User
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class LogoutRequest(BaseModel):
+    refresh_token: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+
+
+class UserProfile(BaseModel):
+    id: str
+    username: str
+    role: str
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(body: LoginRequest, request: Request):
+    """Authenticate with username/password and receive a token pair."""
+    provider = request.app.state.auth_provider
+    try:
+        pair = await provider.authenticate({
+            "username": body.username,
+            "password": body.password,
+        })
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid username or password",
+        )
+    return TokenResponse(access_token=pair.access_token, refresh_token=pair.refresh_token)
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh(body: RefreshRequest, request: Request):
+    """Exchange a refresh token for a new token pair."""
+    provider = request.app.state.auth_provider
+    try:
+        pair = await provider.refresh_token(body.refresh_token)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+    return TokenResponse(access_token=pair.access_token, refresh_token=pair.refresh_token)
+
+
+@router.post("/logout")
+async def logout(
+    body: LogoutRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+):
+    """Revoke a refresh token (logout)."""
+    provider = request.app.state.auth_provider
+    await provider.revoke_token(body.refresh_token)
+    return {"detail": "Logged out"}
+
+
+@router.get("/me", response_model=UserProfile)
+async def me(user: User = Depends(get_current_user)):
+    """Return the current user's profile."""
+    return UserProfile(id=user.id, username=user.username, role=user.role)

--- a/web/api/calendar.py
+++ b/web/api/calendar.py
@@ -13,6 +13,7 @@ from datetime import date, datetime, timedelta
 from typing import Optional, List
 from config_manager import AppConfig
 from logger import JournalSummarizerLogger, ErrorCategory
+from web.auth import get_current_user, User
 from web.services.calendar_service import CalendarService
 from web.models.journal import CalendarMonth, CalendarEntry, TodayResponse
 
@@ -26,7 +27,8 @@ def get_calendar_service(request: Request) -> CalendarService:
 
 @router.get("/today", response_model=TodayResponse)
 async def get_today_info(
-    calendar_service: CalendarService = Depends(get_calendar_service)
+    calendar_service: CalendarService = Depends(get_calendar_service),
+    user: User = Depends(get_current_user)
 ):
     """Get information about today's date and entry status."""
     try:
@@ -54,7 +56,8 @@ async def get_today_info(
 
 @router.get("/current")
 async def get_current_month(
-    calendar_service: CalendarService = Depends(get_calendar_service)
+    calendar_service: CalendarService = Depends(get_calendar_service),
+    user: User = Depends(get_current_user)
 ):
     """Get current month calendar data."""
     try:
@@ -72,7 +75,8 @@ async def get_current_month(
 @router.get("/week/{entry_date}")
 async def get_week_info(
     entry_date: date,
-    calendar_service: CalendarService = Depends(get_calendar_service)
+    calendar_service: CalendarService = Depends(get_calendar_service),
+    user: User = Depends(get_current_user)
 ):
     """Get week information for a specific date."""
     try:
@@ -103,7 +107,8 @@ async def get_week_info(
 async def get_calendar_stats(
     year: Optional[int] = Query(None, description="Year for stats (default: current year)"),
     month: Optional[int] = Query(None, description="Month for stats (default: all months)"),
-    calendar_service: CalendarService = Depends(get_calendar_service)
+    calendar_service: CalendarService = Depends(get_calendar_service),
+    user: User = Depends(get_current_user)
 ):
     """Get calendar statistics for a specific year or month."""
     try:
@@ -182,7 +187,8 @@ async def get_calendar_stats(
 @router.get("/months/{year}")
 async def get_year_overview(
     year: int,
-    calendar_service: CalendarService = Depends(get_calendar_service)
+    calendar_service: CalendarService = Depends(get_calendar_service),
+    user: User = Depends(get_current_user)
 ):
     """Get overview of all months in a year with entry counts."""
     try:
@@ -234,7 +240,8 @@ async def get_year_overview(
 @router.get("/date/{entry_date}/exists")
 async def check_entry_exists(
     entry_date: date,
-    calendar_service: CalendarService = Depends(get_calendar_service)
+    calendar_service: CalendarService = Depends(get_calendar_service),
+    user: User = Depends(get_current_user)
 ):
     """Check if an entry exists for a specific date."""
     try:
@@ -258,7 +265,8 @@ async def check_entry_exists(
 async def get_entries_in_range(
     start_date: date,
     end_date: date,
-    calendar_service: CalendarService = Depends(get_calendar_service)
+    calendar_service: CalendarService = Depends(get_calendar_service),
+    user: User = Depends(get_current_user)
 ):
     """Get all entries within a date range."""
     try:
@@ -292,7 +300,8 @@ async def get_entries_in_range(
 async def get_calendar_month(
     year: int,
     month: int,
-    calendar_service: CalendarService = Depends(get_calendar_service)
+    calendar_service: CalendarService = Depends(get_calendar_service),
+    user: User = Depends(get_current_user)
 ):
     """Get calendar data for a specific month and year."""
     try:
@@ -326,7 +335,8 @@ async def get_calendar_month(
 async def get_calendar_navigation(
     year: int,
     month: int,
-    calendar_service: CalendarService = Depends(get_calendar_service)
+    calendar_service: CalendarService = Depends(get_calendar_service),
+    user: User = Depends(get_current_user)
 ):
     """Get navigation information for calendar month view."""
     try:

--- a/web/api/entries.py
+++ b/web/api/entries.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from config_manager import AppConfig
 from logger import JournalSummarizerLogger, ErrorCategory
-from web.auth import get_current_user, User
+from web.auth import get_current_user, require_admin, User
 from web.services.entry_manager import EntryManager
 from web.models.journal import (
     JournalEntryCreate, JournalEntryUpDate, JournalEntryResponse,
@@ -199,7 +199,7 @@ async def update_entry(
 async def delete_entry(
     entry_date: date,
     entry_manager: EntryManager = Depends(get_entry_manager),
-    user: User = Depends(get_current_user)
+    user: User = Depends(require_admin)
 ):
     """
     Delete a journal entry.

--- a/web/api/entries.py
+++ b/web/api/entries.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from config_manager import AppConfig
 from logger import JournalSummarizerLogger, ErrorCategory
+from web.auth import get_current_user, User
 from web.services.entry_manager import EntryManager
 from web.models.journal import (
     JournalEntryCreate, JournalEntryUpDate, JournalEntryResponse,
@@ -38,7 +39,8 @@ async def list_entries(
     offset: int = Query(0, ge=0, description="Offset for pagination"),
     sort_by: str = Query("date", description="Sort field"),
     sort_order: str = Query("desc", regex="^(asc|desc)$", description="Sort order"),
-    entry_manager: EntryManager = Depends(get_entry_manager)
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user)
 ):
     """
     List journal entries with filtering and pagination.
@@ -71,7 +73,8 @@ async def list_entries(
 @router.get("/recent", response_model=RecentEntriesResponse)
 async def get_recent_entries(
     limit: int = Query(10, ge=1, le=50, description="Number of recent entries to return"),
-    entry_manager: EntryManager = Depends(get_entry_manager)
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user)
 ):
     """
     Get recent journal entries.
@@ -90,7 +93,8 @@ async def get_recent_entries(
 async def get_entry(
     entry_date: date,
     include_content: bool = Query(False, description="Include entry content"),
-    entry_manager: EntryManager = Depends(get_entry_manager)
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user)
 ):
     """
     Get a specific journal entry by date.
@@ -115,7 +119,8 @@ async def get_entry(
 async def create_or_update_entry(
     entry_date: date,
     entry_data: JournalEntryCreate,
-    entry_manager: EntryManager = Depends(get_entry_manager)
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user)
 ):
     """
     Create or update a journal entry.
@@ -156,7 +161,8 @@ async def create_or_update_entry(
 async def update_entry(
     entry_date: date,
     entry_data: JournalEntryUpDate,
-    entry_manager: EntryManager = Depends(get_entry_manager)
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user)
 ):
     """
     Update an existing journal entry.
@@ -192,7 +198,8 @@ async def update_entry(
 @router.delete("/{entry_date}")
 async def delete_entry(
     entry_date: date,
-    entry_manager: EntryManager = Depends(get_entry_manager)
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user)
 ):
     """
     Delete a journal entry.
@@ -223,7 +230,8 @@ async def delete_entry(
 @router.get("/{entry_date}/content")
 async def get_entry_content(
     entry_date: date,
-    entry_manager: EntryManager = Depends(get_entry_manager)
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user)
 ):
     """
     Get the raw content of a journal entry.
@@ -248,7 +256,8 @@ async def get_entry_content(
 async def update_entry_content(
     entry_date: date,
     content: str,
-    entry_manager: EntryManager = Depends(get_entry_manager)
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user)
 ):
     """
     Update just the content of a journal entry.
@@ -270,7 +279,8 @@ async def update_entry_content(
 @router.get("/stats/database", response_model=DatabaseStats)
 async def get_database_stats(
     request: Request,
-    entry_manager: EntryManager = Depends(get_entry_manager)
+    entry_manager: EntryManager = Depends(get_entry_manager),
+    user: User = Depends(get_current_user)
 ):
     """
     Get database statistics.

--- a/web/api/health.py
+++ b/web/api/health.py
@@ -14,6 +14,7 @@ from datetime import datetime
 
 from config_manager import AppConfig
 from logger import JournalSummarizerLogger
+from web.auth import require_admin, User
 from web.database import DatabaseManager
 from web.models.responses import HealthResponse
 
@@ -59,7 +60,7 @@ async def health_check(request: Request):
 
 
 @router.get("/config")
-async def config_status(request: Request):
+async def config_status(request: Request, user: User = Depends(require_admin)):
     """Detailed configuration status endpoint."""
     config: AppConfig = request.app.state.config
     
@@ -85,7 +86,7 @@ async def config_status(request: Request):
 
 
 @router.get("/metrics")
-async def system_metrics(request: Request):
+async def system_metrics(request: Request, user: User = Depends(require_admin)):
     """System metrics endpoint."""
     db_manager: DatabaseManager = request.app.state.db_manager
     

--- a/web/api/settings.py
+++ b/web/api/settings.py
@@ -13,6 +13,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+from web.auth import get_current_user, require_admin, User
 from web.services.settings_service import SettingsService
 from web.models.settings import (
     WebSettingResponse, WebSettingCreate, WebSettingUpdate,
@@ -32,7 +33,8 @@ def get_settings_service(request: Request) -> SettingsService:
 
 @router.get("/", response_model=Dict[str, WebSettingResponse])
 async def get_all_settings(
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(get_current_user)
 ):
     """Get all web settings with their current values."""
     try:
@@ -47,7 +49,8 @@ async def get_all_settings(
 
 @router.get("/categories", response_model=SettingsCategoryResponse)
 async def get_settings_categories(
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(get_current_user)
 ):
     """Get settings organized by category."""
     try:
@@ -62,7 +65,8 @@ async def get_settings_categories(
 
 @router.get("/health")
 async def settings_health_check(
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(get_current_user)
 ):
     """Health check for settings service."""
     try:
@@ -127,7 +131,8 @@ async def _build_work_week_config_response(settings: Dict[str, Any]) -> WorkWeek
 
 @router.get("/work-week", response_model=WorkWeekConfigResponse)
 async def get_work_week_configuration(
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(get_current_user)
 ):
     """Get current work week configuration."""
     try:
@@ -143,7 +148,8 @@ async def get_work_week_configuration(
 @router.post("/work-week", response_model=WorkWeekUpdateResponse)
 async def update_work_week_configuration(
     config_request: WorkWeekConfigRequest,
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(require_admin)
 ):
     """Update work week configuration."""
     try:
@@ -180,7 +186,8 @@ async def update_work_week_configuration(
 
 @router.get("/work-week/presets", response_model=WorkWeekPresetsResponse)
 async def get_work_week_presets(
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(get_current_user)
 ):
     """Get available work week presets."""
     try:
@@ -214,7 +221,8 @@ async def get_work_week_presets(
 @router.post("/work-week/validate", response_model=WorkWeekValidationResponse)
 async def validate_work_week_configuration(
     validation_request: WorkWeekValidationRequest,
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(get_current_user)
 ):
     """Validate work week configuration without saving."""
     try:
@@ -273,7 +281,8 @@ async def validate_work_week_configuration(
 @router.get("/{key}", response_model=WebSettingResponse)
 async def get_setting(
     key: str,
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(get_current_user)
 ):
     """Get a specific setting by key."""
     try:
@@ -297,7 +306,8 @@ async def get_setting(
 async def update_setting(
     key: str,
     setting_update: WebSettingUpdate,
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(require_admin)
 ):
     """Update a specific setting."""
     try:
@@ -323,7 +333,8 @@ async def update_setting(
 @router.post("/bulk-update", response_model=SettingsBulkUpdateResponse)
 async def bulk_update_settings(
     bulk_request: SettingsBulkUpdateRequest,
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(require_admin)
 ):
     """Update multiple settings at once with enhanced error handling and logging."""
     operation_start = datetime.now()
@@ -484,7 +495,8 @@ async def bulk_update_settings(
 @router.post("/{key}/reset", response_model=WebSettingResponse)
 async def reset_setting(
     key: str,
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(require_admin)
 ):
     """Reset a setting to its default value."""
     try:
@@ -509,7 +521,8 @@ async def reset_setting(
 
 @router.post("/reset-all", response_model=Dict[str, WebSettingResponse])
 async def reset_all_settings(
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(require_admin)
 ):
     """Reset all settings to their default values."""
     try:
@@ -524,7 +537,8 @@ async def reset_all_settings(
 
 @router.get("/export/current", response_model=SettingsExport)
 async def export_settings(
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(get_current_user)
 ):
     """Export all current settings for backup or transfer."""
     try:
@@ -540,7 +554,8 @@ async def export_settings(
 @router.post("/import", response_model=Dict[str, WebSettingResponse])
 async def import_settings(
     import_data: SettingsImport,
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(require_admin)
 ):
     """Import settings from exported data."""
     try:
@@ -562,7 +577,8 @@ async def import_settings(
 async def validate_filesystem_path(
     path: str,
     create_if_missing: bool = False,
-    settings_service: SettingsService = Depends(get_settings_service)
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(get_current_user)
 ):
     """Validate a filesystem path and optionally create it."""
     try:

--- a/web/api/summarization.py
+++ b/web/api/summarization.py
@@ -17,6 +17,7 @@ import asyncio
 
 from config_manager import AppConfig
 from logger import JournalSummarizerLogger, ErrorCategory
+from web.auth import get_current_user, require_admin, User
 from web.services.web_summarizer import WebSummarizationService, SummaryType, SummaryTaskStatus
 from web.models.journal import SummaryRequest, SummaryTaskResponse, ProgressResponse
 
@@ -133,7 +134,8 @@ def get_summarization_service(request: Request) -> WebSummarizationService:
 async def create_summarization_task(
     request: SummaryRequest,
     background_tasks: BackgroundTasks,
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(require_admin)
 ):
     """Create a new summarization task."""
     try:
@@ -177,7 +179,8 @@ async def create_summarization_task(
 
 @router.get("/tasks", response_model=List[SummaryTaskResponse])
 async def get_all_tasks(
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(get_current_user)
 ):
     """Get all summarization tasks."""
     try:
@@ -209,7 +212,8 @@ async def get_all_tasks(
 @router.get("/tasks/{task_id}", response_model=SummaryTaskResponse)
 async def get_task_status(
     task_id: str,
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(get_current_user)
 ):
     """Get the status of a specific summarization task."""
     try:
@@ -242,7 +246,8 @@ async def get_task_status(
 @router.get("/tasks/{task_id}/progress", response_model=ProgressResponse)
 async def get_task_progress(
     task_id: str,
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(get_current_user)
 ):
     """Get the progress of a specific summarization task."""
     try:
@@ -280,7 +285,8 @@ async def get_task_progress(
 @router.post("/tasks/{task_id}/cancel")
 async def cancel_task(
     task_id: str,
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(require_admin)
 ):
     """Cancel a running summarization task."""
     try:
@@ -299,7 +305,8 @@ async def cancel_task(
 @router.get("/tasks/{task_id}/result")
 async def get_task_result(
     task_id: str,
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(get_current_user)
 ):
     """Get the result of a completed summarization task."""
     try:
@@ -331,7 +338,8 @@ async def get_task_result(
 @router.get("/tasks/{task_id}/download")
 async def download_task_result(
     task_id: str,
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(get_current_user)
 ):
     """Download the result file of a completed summarization task."""
     try:
@@ -363,7 +371,8 @@ async def download_task_result(
 @router.delete("/tasks/{task_id}")
 async def delete_task(
     task_id: str,
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(require_admin)
 ):
     """Delete a summarization task."""
     try:
@@ -393,7 +402,8 @@ async def delete_task(
 @router.post("/cleanup")
 async def cleanup_completed_tasks(
     older_than_hours: int = 24,
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(require_admin)
 ):
     """Clean up completed tasks older than specified hours."""
     try:
@@ -416,7 +426,8 @@ async def cleanup_completed_tasks(
 
 @router.get("/stats")
 async def get_summarization_stats(
-    summarization_service: WebSummarizationService = Depends(get_summarization_service)
+    summarization_service: WebSummarizationService = Depends(get_summarization_service),
+    user: User = Depends(get_current_user)
 ):
     """Get summarization service statistics."""
     try:

--- a/web/api/sync.py
+++ b/web/api/sync.py
@@ -13,6 +13,7 @@ from datetime import date, datetime, timedelta
 from typing import Optional, Dict, Any
 from config_manager import AppConfig
 from logger import JournalSummarizerLogger
+from web.auth import get_current_user, require_admin, User
 from web.database import DatabaseManager
 from web.services.sync_service import DatabaseSyncService, SyncType
 from web.services.scheduler import SyncScheduler
@@ -31,7 +32,10 @@ def get_scheduler(request: Request) -> SyncScheduler:
 
 
 @router.get("/status")
-async def get_sync_status(sync_service: DatabaseSyncService = Depends(get_sync_service)):
+async def get_sync_status(
+    sync_service: DatabaseSyncService = Depends(get_sync_service),
+    user: User = Depends(get_current_user)
+):
     """
     Get current synchronization status and recent sync history.
     
@@ -52,7 +56,10 @@ async def get_sync_status(sync_service: DatabaseSyncService = Depends(get_sync_s
 
 
 @router.get("/scheduler/status")
-async def get_scheduler_status(scheduler: SyncScheduler = Depends(get_scheduler)):
+async def get_scheduler_status(
+    scheduler: SyncScheduler = Depends(get_scheduler),
+    user: User = Depends(get_current_user)
+):
     """
     Get scheduler status and configuration.
     
@@ -72,7 +79,8 @@ async def get_scheduler_status(scheduler: SyncScheduler = Depends(get_scheduler)
 async def trigger_full_sync(
     background_tasks: BackgroundTasks,
     date_range_days: Optional[int] = None,
-    sync_service: DatabaseSyncService = Depends(get_sync_service)
+    sync_service: DatabaseSyncService = Depends(get_sync_service),
+    user: User = Depends(require_admin)
 ):
     """
     Trigger a full synchronization between file system and database.
@@ -108,7 +116,8 @@ async def trigger_full_sync(
 async def trigger_incremental_sync(
     request: Request,
     background_tasks: BackgroundTasks,
-    sync_service: DatabaseSyncService = Depends(get_sync_service)
+    sync_service: DatabaseSyncService = Depends(get_sync_service),
+    user: User = Depends(require_admin)
 ):
     """
     Trigger an incremental synchronization for recent changes.
@@ -147,7 +156,8 @@ async def trigger_incremental_sync(
 async def sync_single_entry(
     entry_date: date,
     background_tasks: BackgroundTasks,
-    sync_service: DatabaseSyncService = Depends(get_sync_service)
+    sync_service: DatabaseSyncService = Depends(get_sync_service),
+    user: User = Depends(require_admin)
 ):
     """
     Synchronize a specific entry by date.
@@ -173,7 +183,10 @@ async def sync_single_entry(
 
 
 @router.post("/scheduler/start")
-async def start_scheduler(scheduler: SyncScheduler = Depends(get_scheduler)):
+async def start_scheduler(
+    scheduler: SyncScheduler = Depends(get_scheduler),
+    user: User = Depends(require_admin)
+):
     """
     Start the sync scheduler.
     
@@ -194,7 +207,10 @@ async def start_scheduler(scheduler: SyncScheduler = Depends(get_scheduler)):
 
 
 @router.post("/scheduler/stop")
-async def stop_scheduler(scheduler: SyncScheduler = Depends(get_scheduler)):
+async def stop_scheduler(
+    scheduler: SyncScheduler = Depends(get_scheduler),
+    user: User = Depends(require_admin)
+):
     """
     Stop the sync scheduler.
     
@@ -215,7 +231,10 @@ async def stop_scheduler(scheduler: SyncScheduler = Depends(get_scheduler)):
 
 
 @router.post("/scheduler/trigger/incremental")
-async def trigger_scheduler_incremental(scheduler: SyncScheduler = Depends(get_scheduler)):
+async def trigger_scheduler_incremental(
+    scheduler: SyncScheduler = Depends(get_scheduler),
+    user: User = Depends(require_admin)
+):
     """
     Manually trigger an incremental sync via scheduler.
     
@@ -237,7 +256,10 @@ async def trigger_scheduler_incremental(scheduler: SyncScheduler = Depends(get_s
 
 
 @router.post("/scheduler/trigger/full")
-async def trigger_scheduler_full(scheduler: SyncScheduler = Depends(get_scheduler)):
+async def trigger_scheduler_full(
+    scheduler: SyncScheduler = Depends(get_scheduler),
+    user: User = Depends(require_admin)
+):
     """
     Manually trigger a full sync via scheduler.
     
@@ -262,7 +284,8 @@ async def trigger_scheduler_full(scheduler: SyncScheduler = Depends(get_schedule
 async def update_scheduler_config(
     incremental_seconds: Optional[int] = None,
     full_hours: Optional[int] = None,
-    scheduler: SyncScheduler = Depends(get_scheduler)
+    scheduler: SyncScheduler = Depends(get_scheduler),
+    user: User = Depends(require_admin)
 ):
     """
     Update scheduler configuration.
@@ -295,7 +318,8 @@ async def update_scheduler_config(
 async def get_sync_history(
     limit: int = 10,
     sync_type: Optional[str] = None,
-    sync_service: DatabaseSyncService = Depends(get_sync_service)
+    sync_service: DatabaseSyncService = Depends(get_sync_service),
+    user: User = Depends(get_current_user)
 ):
     """
     Get synchronization history.

--- a/web/app.py
+++ b/web/app.py
@@ -26,6 +26,7 @@ from logger import LogConfig, JournalSummarizerLogger, ErrorCategory
 from web.database import DatabaseManager, db_manager
 from web.api import health, entries, sync, calendar, summarization, settings, auth as auth_api
 from web.providers.local import LocalAuthProvider
+from web.auth import decode_access_token
 from web.middleware import LoggingMiddleware, ErrorHandlingMiddleware
 from web.services.entry_manager import EntryManager
 from web.services.calendar_service import CalendarService
@@ -274,6 +275,19 @@ async def test_page(request: Request):
 @app.websocket("/ws")
 async def general_websocket_endpoint(websocket: WebSocket):
     """General WebSocket endpoint for system-wide updates."""
+    auth_config = getattr(websocket.app.state, "auth_config", None)
+
+    if auth_config and auth_config.enabled:
+        token = websocket.query_params.get("token")
+        if not token:
+            await websocket.close(code=4001, reason="Missing token")
+            return
+        try:
+            decode_access_token(token, auth_config.secret_key)
+        except Exception:
+            await websocket.close(code=4001, reason="Invalid token")
+            return
+
     await websocket.accept()
     try:
         # Send initial connection status
@@ -283,13 +297,13 @@ async def general_websocket_endpoint(websocket: WebSocket):
             "message": "WebSocket connection established",
             "service": "general"
         }))
-        
+
         while True:
             # Keep connection alive and handle any incoming messages
             data = await websocket.receive_text()
             # Echo back for connection testing
             await websocket.send_text(json.dumps({
-                "type": "connection_status", 
+                "type": "connection_status",
                 "status": "connected",
                 "message": "WebSocket connection established"
             }))

--- a/web/app.py
+++ b/web/app.py
@@ -21,10 +21,11 @@ import json
 from pathlib import Path
 from typing import Dict, Any, Optional
 
-from config_manager import ConfigManager, AppConfig
+from config_manager import ConfigManager, AppConfig, AuthConfig
 from logger import LogConfig, JournalSummarizerLogger, ErrorCategory
 from web.database import DatabaseManager, db_manager
-from web.api import health, entries, sync, calendar, summarization, settings
+from web.api import health, entries, sync, calendar, summarization, settings, auth as auth_api
+from web.providers.local import LocalAuthProvider
 from web.middleware import LoggingMiddleware, ErrorHandlingMiddleware
 from web.services.entry_manager import EntryManager
 from web.services.calendar_service import CalendarService
@@ -156,7 +157,12 @@ async def lifespan(app: FastAPI):
     app.state.sync_service = web_app.sync_service
     app.state.summarization_service = web_app.summarization_service
     app.state.scheduler = web_app.scheduler
-    
+    app.state.auth_config = web_app.config.auth
+    if web_app.config.auth.enabled:
+        app.state.auth_provider = LocalAuthProvider(web_app.db_manager, web_app.config.auth)
+    else:
+        app.state.auth_provider = None
+
     yield
     
     # Shutdown
@@ -199,6 +205,7 @@ app.include_router(sync.router)
 app.include_router(calendar.router)
 app.include_router(summarization.router)
 app.include_router(settings.router)
+app.include_router(auth_api.router)
 
 # Static files and templates
 static_dir = Path(__file__).parent / "static"

--- a/web/auth.py
+++ b/web/auth.py
@@ -1,4 +1,4 @@
-# ABOUTME: Authentication protocol, user model, JWT utilities, and FastAPI dependencies.
+# ABOUTME: Authentication types, provider protocol, and JWT encode/decode utilities.
 # ABOUTME: Provides the pluggable auth provider interface and token validation.
 
 from dataclasses import dataclass

--- a/web/auth.py
+++ b/web/auth.py
@@ -1,11 +1,12 @@
-# ABOUTME: Authentication types, provider protocol, and JWT encode/decode utilities.
-# ABOUTME: Provides the pluggable auth provider interface and token validation.
+# ABOUTME: Authentication types, provider protocol, JWT utilities, and FastAPI dependencies.
+# ABOUTME: Provides the pluggable auth provider interface, token validation, and route guards.
 
 from dataclasses import dataclass
 from typing import Protocol
 from datetime import datetime, timedelta, timezone
 
 import jwt
+from fastapi import Request, Depends, HTTPException, status
 
 
 @dataclass
@@ -48,3 +49,54 @@ def encode_access_token(user: User, secret: str, ttl_seconds: int = 1800) -> str
 def decode_access_token(token: str, secret: str) -> dict:
     """Decode and validate a JWT access token. Raises on expiry or bad signature."""
     return jwt.decode(token, secret, algorithms=["HS256"])
+
+
+_DEFAULT_USER = User(id="default", username="default", role="admin")
+
+
+async def get_current_user(request: Request) -> User:
+    """FastAPI dependency: extract and validate the Bearer token, return User."""
+    auth_config = request.app.state.auth_config
+
+    if not auth_config.enabled:
+        return _DEFAULT_USER
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or invalid Authorization header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = auth_header[len("Bearer "):]
+    try:
+        payload = decode_access_token(token, auth_config.secret_key)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return User(
+        id=payload["user_id"],
+        username=payload["username"],
+        role=payload["role"],
+    )
+
+
+async def require_admin(user: User = Depends(get_current_user)) -> User:
+    """FastAPI dependency: require the current user to be an admin."""
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return user

--- a/web/auth.py
+++ b/web/auth.py
@@ -51,15 +51,12 @@ def decode_access_token(token: str, secret: str) -> dict:
     return jwt.decode(token, secret, algorithms=["HS256"])
 
 
-_DEFAULT_USER = User(id="default", username="default", role="admin")
-
-
 async def get_current_user(request: Request) -> User:
     """FastAPI dependency: extract and validate the Bearer token, return User."""
     auth_config = request.app.state.auth_config
 
     if not auth_config.enabled:
-        return _DEFAULT_USER
+        return User(id="default", username="default", role="admin")
 
     auth_header = request.headers.get("authorization", "")
     if not auth_header.startswith("Bearer "):
@@ -85,11 +82,18 @@ async def get_current_user(request: Request) -> User:
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    return User(
-        id=payload["user_id"],
-        username=payload["username"],
-        role=payload["role"],
-    )
+    try:
+        return User(
+            id=payload["user_id"],
+            username=payload["username"],
+            role=payload["role"],
+        )
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
 
 async def require_admin(user: User = Depends(get_current_user)) -> User:

--- a/web/auth.py
+++ b/web/auth.py
@@ -1,0 +1,50 @@
+# ABOUTME: Authentication protocol, user model, JWT utilities, and FastAPI dependencies.
+# ABOUTME: Provides the pluggable auth provider interface and token validation.
+
+from dataclasses import dataclass
+from typing import Protocol
+from datetime import datetime, timedelta, timezone
+
+import jwt
+
+
+@dataclass
+class User:
+    """Authenticated user identity."""
+    id: str
+    username: str
+    role: str
+
+
+@dataclass
+class TokenPair:
+    """Access and refresh token pair returned after authentication."""
+    access_token: str
+    refresh_token: str
+
+
+class AuthProvider(Protocol):
+    """Pluggable authentication provider interface."""
+
+    async def authenticate(self, credentials: dict) -> TokenPair: ...
+    async def validate_token(self, token: str) -> User: ...
+    async def refresh_token(self, raw_refresh_token: str) -> TokenPair: ...
+    async def revoke_token(self, raw_refresh_token: str) -> None: ...
+
+
+def encode_access_token(user: User, secret: str, ttl_seconds: int = 1800) -> str:
+    """Encode a JWT access token for the given user."""
+    now = datetime.now(timezone.utc)
+    payload = {
+        "user_id": user.id,
+        "username": user.username,
+        "role": user.role,
+        "iat": now,
+        "exp": now + timedelta(seconds=ttl_seconds),
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def decode_access_token(token: str, secret: str) -> dict:
+    """Decode and validate a JWT access token. Raises on expiry or bad signature."""
+    return jwt.decode(token, secret, algorithms=["HS256"])

--- a/web/auth.py
+++ b/web/auth.py
@@ -53,9 +53,9 @@ def decode_access_token(token: str, secret: str) -> dict:
 
 async def get_current_user(request: Request) -> User:
     """FastAPI dependency: extract and validate the Bearer token, return User."""
-    auth_config = request.app.state.auth_config
+    auth_config = getattr(request.app.state, "auth_config", None)
 
-    if not auth_config.enabled:
+    if auth_config is None or not auth_config.enabled:
         return User(id="default", username="default", role="admin")
 
     auth_header = request.headers.get("authorization", "")

--- a/web/database.py
+++ b/web/database.py
@@ -41,7 +41,8 @@ class JournalEntryIndex(Base):
     character_count = Column(Integer, default=0)
     line_count = Column(Integer, default=0)
     has_content = Column(Boolean, default=False, index=True)
-    
+    user_id = Column(String, nullable=False, default="default", index=True)
+
     # File system metadata
     file_size_bytes = Column(Integer, default=0)
     file_modified_at = Column(DateTime)

--- a/web/database.py
+++ b/web/database.py
@@ -131,8 +131,6 @@ Index('idx_journal_entries_week_ending', JournalEntryIndex.week_ending_date)
 Index('idx_sync_status_type_started', SyncStatus.sync_type, SyncStatus.started_at)
 Index('idx_work_week_settings_user', WorkWeekSettings.user_id)
 Index('idx_work_week_settings_preset', WorkWeekSettings.work_week_preset)
-Index('idx_users_username', UserAccount.username)
-Index('idx_refresh_tokens_user', RefreshToken.user_id)
 Index('idx_refresh_tokens_hash', RefreshToken.token_hash)
 
 

--- a/web/database.py
+++ b/web/database.py
@@ -100,12 +100,40 @@ class SyncStatus(Base):
     sync_metadata = Column(Text)  # JSON metadata
 
 
+class UserAccount(Base):
+    """User account for authentication (local provider)."""
+    __tablename__ = "users"
+
+    id = Column(String, primary_key=True)
+    username = Column(String, unique=True, nullable=False, index=True)
+    password_hash = Column(String, nullable=False)
+    role = Column(String, nullable=False, default="user")
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, default=now_utc)
+    modified_at = Column(DateTime, default=now_utc, onupdate=now_utc)
+
+
+class RefreshToken(Base):
+    """Revocable refresh token (stores hash, not raw token)."""
+    __tablename__ = "refresh_tokens"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(String, nullable=False, index=True)
+    token_hash = Column(String, nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    revoked = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime, default=now_utc)
+
+
 # Add database indexes for performance
 Index('idx_journal_entries_date_content', JournalEntryIndex.date, JournalEntryIndex.has_content)
 Index('idx_journal_entries_week_ending', JournalEntryIndex.week_ending_date)
 Index('idx_sync_status_type_started', SyncStatus.sync_type, SyncStatus.started_at)
 Index('idx_work_week_settings_user', WorkWeekSettings.user_id)
 Index('idx_work_week_settings_preset', WorkWeekSettings.work_week_preset)
+Index('idx_users_username', UserAccount.username)
+Index('idx_refresh_tokens_user', RefreshToken.user_id)
+Index('idx_refresh_tokens_hash', RefreshToken.token_hash)
 
 
 class DatabaseManager:

--- a/web/manage.py
+++ b/web/manage.py
@@ -32,7 +32,10 @@ async def create_admin(db: DatabaseManager, username: str, password: str) -> str
             role="admin",
             is_active=True,
         ))
-        await session.commit()
+        try:
+            await session.commit()
+        except IntegrityError:
+            raise ValueError(f"Username '{username}' already exists")
 
     return user_id
 

--- a/web/manage.py
+++ b/web/manage.py
@@ -1,0 +1,96 @@
+# ABOUTME: CLI tool for user account management (create-admin, list-users).
+# ABOUTME: Bootstraps the first admin user without requiring API authentication.
+
+import argparse
+import asyncio
+import getpass
+import sys
+import uuid
+
+import bcrypt
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from web.database import DatabaseManager, UserAccount
+
+
+async def create_admin(db: DatabaseManager, username: str, password: str) -> str:
+    """Create an admin user account. Returns the new user's ID."""
+    pw_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    user_id = str(uuid.uuid4())
+
+    async with db.get_session() as session:
+        stmt = select(UserAccount).where(UserAccount.username == username)
+        result = await session.execute(stmt)
+        if result.scalar_one_or_none() is not None:
+            raise ValueError(f"Username '{username}' already exists")
+
+        session.add(UserAccount(
+            id=user_id,
+            username=username,
+            password_hash=pw_hash,
+            role="admin",
+            is_active=True,
+        ))
+        await session.commit()
+
+    return user_id
+
+
+async def list_users(db: DatabaseManager) -> list:
+    """List all user accounts (without password hashes)."""
+    async with db.get_session() as session:
+        stmt = select(UserAccount).order_by(UserAccount.created_at)
+        result = await session.execute(stmt)
+        accounts = result.scalars().all()
+
+    return [
+        {
+            "id": a.id,
+            "username": a.username,
+            "role": a.role,
+            "is_active": a.is_active,
+            "created_at": a.created_at.isoformat() if a.created_at else None,
+        }
+        for a in accounts
+    ]
+
+
+async def _main(args: argparse.Namespace) -> None:
+    db = DatabaseManager()
+    await db.initialize()
+
+    if args.command == "create-admin":
+        password = args.password or getpass.getpass("Password: ")
+        user_id = await create_admin(db, args.username, password)
+        print(f"Admin user '{args.username}' created (id: {user_id})")
+
+    elif args.command == "list-users":
+        users = await list_users(db)
+        if not users:
+            print("No users found.")
+        else:
+            for u in users:
+                status = "active" if u["is_active"] else "disabled"
+                print(f"  {u['username']}  role={u['role']}  {status}  id={u['id']}")
+
+    if db.engine:
+        await db.engine.dispose()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Work Journal Maker user management")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create_parser = sub.add_parser("create-admin", help="Create an admin user")
+    create_parser.add_argument("--username", required=True)
+    create_parser.add_argument("--password", default=None, help="Password (prompted if omitted)")
+
+    sub.add_parser("list-users", help="List all users")
+
+    args = parser.parse_args()
+    asyncio.run(_main(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/web/providers/__init__.py
+++ b/web/providers/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Authentication provider package.
+# ABOUTME: Contains pluggable provider implementations (local, future SSO).

--- a/web/providers/local.py
+++ b/web/providers/local.py
@@ -1,0 +1,127 @@
+# ABOUTME: Local username/password authentication provider using bcrypt and JWT.
+# ABOUTME: Manages user verification, token issuance, refresh token rotation, and revocation.
+
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import bcrypt
+from sqlalchemy import select
+
+from config_manager import AuthConfig
+from web.auth import AuthProvider, User, TokenPair, encode_access_token, decode_access_token
+from web.database import DatabaseManager, UserAccount, RefreshToken
+
+
+class AuthenticationError(Exception):
+    """Raised when authentication fails."""
+    pass
+
+
+class LocalAuthProvider:
+    """Authenticates users against local database with bcrypt-hashed passwords."""
+
+    def __init__(self, db: DatabaseManager, config: AuthConfig):
+        self.db = db
+        self.config = config
+
+    async def authenticate(self, credentials: dict) -> TokenPair:
+        """Verify username/password and return a token pair."""
+        username = credentials.get("username", "")
+        password = credentials.get("password", "")
+
+        async with self.db.get_session() as session:
+            stmt = select(UserAccount).where(UserAccount.username == username)
+            result = await session.execute(stmt)
+            account = result.scalar_one_or_none()
+
+        if account is None:
+            raise AuthenticationError("Invalid username or password")
+
+        if not account.is_active:
+            raise AuthenticationError("Account is disabled")
+
+        if not bcrypt.checkpw(password.encode(), account.password_hash.encode()):
+            raise AuthenticationError("Invalid username or password")
+
+        user = User(id=account.id, username=account.username, role=account.role)
+        return await self._issue_token_pair(user)
+
+    async def validate_token(self, token: str) -> User:
+        """Decode a JWT access token and return the User."""
+        payload = decode_access_token(token, self.config.secret_key)
+        return User(
+            id=payload["user_id"],
+            username=payload["username"],
+            role=payload["role"],
+        )
+
+    async def refresh_token(self, raw_refresh_token: str) -> TokenPair:
+        """Exchange a valid refresh token for a new token pair."""
+        token_hash = self._hash_refresh_token(raw_refresh_token)
+
+        async with self.db.get_session() as session:
+            stmt = select(RefreshToken).where(
+                RefreshToken.token_hash == token_hash,
+                RefreshToken.revoked == False,
+            )
+            result = await session.execute(stmt)
+            stored = result.scalar_one_or_none()
+
+            if stored is None:
+                raise AuthenticationError("Invalid or revoked refresh token")
+
+            if stored.expires_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
+                raise AuthenticationError("Refresh token has expired")
+
+            # Revoke the old token (rotation)
+            stored.revoked = True
+            await session.commit()
+
+        # Look up user to build new tokens
+        async with self.db.get_session() as session:
+            stmt = select(UserAccount).where(UserAccount.id == stored.user_id)
+            result = await session.execute(stmt)
+            account = result.scalar_one_or_none()
+
+        if account is None or not account.is_active:
+            raise AuthenticationError("User account not found or disabled")
+
+        user = User(id=account.id, username=account.username, role=account.role)
+        return await self._issue_token_pair(user)
+
+    async def revoke_token(self, raw_refresh_token: str) -> None:
+        """Revoke a refresh token (logout)."""
+        token_hash = self._hash_refresh_token(raw_refresh_token)
+
+        async with self.db.get_session() as session:
+            stmt = select(RefreshToken).where(RefreshToken.token_hash == token_hash)
+            result = await session.execute(stmt)
+            stored = result.scalar_one_or_none()
+            if stored:
+                stored.revoked = True
+                await session.commit()
+
+    async def _issue_token_pair(self, user: User) -> TokenPair:
+        """Create a new access + refresh token pair and persist the refresh token hash."""
+        access_token = encode_access_token(
+            user, self.config.secret_key, ttl_seconds=self.config.access_token_ttl
+        )
+        raw_refresh = uuid.uuid4().hex + uuid.uuid4().hex
+        token_hash = self._hash_refresh_token(raw_refresh)
+
+        async with self.db.get_session() as session:
+            session.add(RefreshToken(
+                id=str(uuid.uuid4()),
+                user_id=user.id,
+                token_hash=token_hash,
+                expires_at=datetime.now(timezone.utc) + timedelta(seconds=self.config.refresh_token_ttl),
+            ))
+            await session.commit()
+
+        return TokenPair(access_token=access_token, refresh_token=raw_refresh)
+
+    @staticmethod
+    def _hash_refresh_token(raw_token: str) -> str:
+        """SHA-256 hash a raw refresh token for storage."""
+        return hashlib.sha256(raw_token.encode()).hexdigest()

--- a/web/providers/local.py
+++ b/web/providers/local.py
@@ -18,6 +18,11 @@ class AuthenticationError(Exception):
     pass
 
 
+# Computed once at import time; used to keep response time consistent when a
+# username does not exist (prevents timing-based user enumeration).
+_DUMMY_HASH = bcrypt.hashpw(b"dummy", bcrypt.gensalt()).decode()
+
+
 class LocalAuthProvider:
     """Authenticates users against local database with bcrypt-hashed passwords."""
 
@@ -36,6 +41,7 @@ class LocalAuthProvider:
             account = result.scalar_one_or_none()
 
         if account is None:
+            bcrypt.checkpw(password.encode(), _DUMMY_HASH.encode())
             raise AuthenticationError("Invalid username or password")
 
         if not account.is_active:
@@ -74,20 +80,21 @@ class LocalAuthProvider:
             if stored.expires_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
                 raise AuthenticationError("Refresh token has expired")
 
-            # Revoke the old token (rotation)
+            # Fetch the user in the same session before revoking the token.
+            user_stmt = select(UserAccount).where(UserAccount.id == stored.user_id)
+            user_result = await session.execute(user_stmt)
+            account = user_result.scalar_one_or_none()
+
+            if account is None or not account.is_active:
+                raise AuthenticationError("User account not found or disabled")
+
+            # Capture values before closing the session.
+            user = User(id=account.id, username=account.username, role=account.role)
+
+            # Revoke the old token (rotation).
             stored.revoked = True
             await session.commit()
 
-        # Look up user to build new tokens
-        async with self.db.get_session() as session:
-            stmt = select(UserAccount).where(UserAccount.id == stored.user_id)
-            result = await session.execute(stmt)
-            account = result.scalar_one_or_none()
-
-        if account is None or not account.is_active:
-            raise AuthenticationError("User account not found or disabled")
-
-        user = User(id=account.id, username=account.username, role=account.role)
         return await self._issue_token_pair(user)
 
     async def revoke_token(self, raw_refresh_token: str) -> None:


### PR DESCRIPTION
## Summary

- Adds a complete authentication system to all web API endpoints, closing #87
- Pluggable `AuthProvider` protocol with a local username/password implementation (bcrypt + JWT)
- Auth-optional mode via `auth.enabled` config toggle — when disabled, all endpoints behave as before (no breaking changes)
- Two roles: `user` (read/write own entries) and `admin` (destructive operations, scheduler control)
- CLI management tool (`web/manage.py`) for bootstrapping admin users without API access
- WebSocket connections validated via query parameter token
- `user_id` column added to `JournalEntryIndex` for future multi-user scoping

## What's included

| Area | Files | Purpose |
|------|-------|---------|
| Core auth | `web/auth.py` | AuthProvider protocol, User/TokenPair types, JWT encode/decode, FastAPI dependencies |
| Local provider | `web/providers/local.py` | bcrypt password verification, token issuance, refresh token rotation |
| Auth API | `web/api/auth.py` | `/api/auth/login`, `/refresh`, `/logout`, `/me` endpoints |
| Endpoint protection | `web/api/{entries,settings,sync,health,calendar,summarization}.py` | Auth dependency injection on all routes |
| CLI tool | `web/manage.py` | `create-admin` and `list-users` subcommands |
| Config | `config_manager.py` | `AuthConfig` dataclass with `WJS_AUTH_SECRET_KEY` env var override |
| DB models | `web/database.py` | `UserAccount`, `RefreshToken` tables; `user_id` on `JournalEntryIndex` |
| Tests | 5 new test files (66 tests) | Unit, integration, and endpoint protection tests — all passing |

## Design decisions

- **Stateless access tokens / revocable refresh tokens**: Access tokens are JWT (no DB lookup per request). Refresh tokens are SHA-256 hashed and stored in DB, enabling revocation and rotation.
- **Auth-disabled default**: `AuthConfig.enabled=False` returns a default admin user from `get_current_user`, so zero config change is needed for existing single-user deployments.
- **Protocol-based provider**: Swapping to LBNL SSO later requires implementing 4 methods (`authenticate`, `validate_token`, `refresh_token`, `revoke_token`).

## Test plan

- [x] All 66 auth tests pass (`test_auth.py`, `test_auth_provider_local.py`, `test_auth_api.py`, `test_auth_protected.py`, `test_manage.py`)
- [x] Full test suite: 1477 pass, 85 pre-existing failures (none auth-related)
- [x] CLI tool shows help with both subcommands
- [x] No regressions in existing endpoint behavior with auth disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)