### PR TITLE
fix: add migration for missing user_id column in journal_entries

### DIFF
--- a/tests/test_migration_002_user_id.py
+++ b/tests/test_migration_002_user_id.py
@@ -1,0 +1,195 @@
+# ABOUTME: Tests for migration 002 — adding user_id column to journal_entries.
+# ABOUTME: Verifies both auto-migration in DatabaseManager and standalone script.
+
+import asyncio
+import sqlite3
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def create_legacy_database(db_path: str):
+    """Create a journal_entries table without the user_id column."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE journal_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date DATE NOT NULL UNIQUE,
+            file_path TEXT NOT NULL,
+            week_ending_date DATE NOT NULL,
+            word_count INTEGER DEFAULT 0,
+            character_count INTEGER DEFAULT 0,
+            line_count INTEGER DEFAULT 0,
+            has_content BOOLEAN DEFAULT 0,
+            file_size_bytes INTEGER DEFAULT 0,
+            file_modified_at DATETIME,
+            last_accessed_at DATETIME,
+            access_count INTEGER DEFAULT 0,
+            created_at DATETIME,
+            modified_at DATETIME,
+            synced_at DATETIME
+        )
+    """)
+    conn.execute("CREATE INDEX ix_journal_entries_date ON journal_entries(date)")
+    conn.execute("CREATE INDEX ix_journal_entries_has_content ON journal_entries(has_content)")
+    conn.execute("CREATE INDEX ix_journal_entries_week_ending_date ON journal_entries(week_ending_date)")
+    conn.execute("""
+        INSERT INTO journal_entries (date, file_path, week_ending_date, word_count, has_content)
+        VALUES ('2026-05-20', '/tmp/worklog_2026-05-20.txt', '2026-05-23', 100, 1)
+    """)
+    conn.commit()
+    conn.close()
+
+
+def get_columns(db_path: str, table: str) -> list:
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute(f"PRAGMA table_info({table})")
+    columns = [row[1] for row in cursor.fetchall()]
+    conn.close()
+    return columns
+
+
+def get_indexes(db_path: str, table: str) -> list:
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute(f"PRAGMA index_list({table})")
+    indexes = [row[1] for row in cursor.fetchall()]
+    conn.close()
+    return indexes
+
+
+class TestDatabaseManagerAutoMigration:
+    """Test that DatabaseManager.initialize() auto-migrates missing user_id."""
+
+    @pytest.mark.asyncio
+    async def test_adds_user_id_to_legacy_database(self, tmp_path):
+        db_path = str(tmp_path / "test_journal.db")
+        create_legacy_database(db_path)
+
+        assert "user_id" not in get_columns(db_path, "journal_entries")
+
+        from web.database import DatabaseManager
+        dm = DatabaseManager()
+        with patch.object(dm, 'database_path', db_path):
+            await dm.initialize()
+
+        columns = get_columns(db_path, "journal_entries")
+        assert "user_id" in columns
+
+    @pytest.mark.asyncio
+    async def test_existing_rows_get_default_user_id(self, tmp_path):
+        db_path = str(tmp_path / "test_journal.db")
+        create_legacy_database(db_path)
+
+        from web.database import DatabaseManager
+        dm = DatabaseManager()
+        with patch.object(dm, 'database_path', db_path):
+            await dm.initialize()
+
+        conn = sqlite3.connect(db_path)
+        cursor = conn.execute("SELECT user_id FROM journal_entries")
+        rows = cursor.fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0][0] == "default"
+
+    @pytest.mark.asyncio
+    async def test_creates_user_id_index(self, tmp_path):
+        db_path = str(tmp_path / "test_journal.db")
+        create_legacy_database(db_path)
+
+        from web.database import DatabaseManager
+        dm = DatabaseManager()
+        with patch.object(dm, 'database_path', db_path):
+            await dm.initialize()
+
+        indexes = get_indexes(db_path, "journal_entries")
+        assert any("user_id" in idx for idx in indexes)
+
+    @pytest.mark.asyncio
+    async def test_noop_when_column_exists(self, tmp_path):
+        """If user_id already exists, migration should be a no-op."""
+        db_path = str(tmp_path / "test_journal.db")
+        create_legacy_database(db_path)
+
+        # Manually add user_id first
+        conn = sqlite3.connect(db_path)
+        conn.execute("ALTER TABLE journal_entries ADD COLUMN user_id TEXT NOT NULL DEFAULT 'default'")
+        conn.commit()
+        conn.close()
+
+        assert "user_id" in get_columns(db_path, "journal_entries")
+
+        from web.database import DatabaseManager
+        dm = DatabaseManager()
+        with patch.object(dm, 'database_path', db_path):
+            await dm.initialize()
+
+        # Should still work fine
+        columns = get_columns(db_path, "journal_entries")
+        assert "user_id" in columns
+
+
+class TestStandaloneMigration:
+    """Test the standalone migration script."""
+
+    @pytest.mark.asyncio
+    async def test_check_migration_needed_on_legacy_db(self, tmp_path):
+        db_path = str(tmp_path / "test_journal.db")
+        create_legacy_database(db_path)
+
+        from web.migrations.migration_002_add_user_id import UserIdMigration
+        migration = UserIdMigration(db_path)
+        await migration.initialize()
+
+        assert await migration.check_migration_needed() is True
+        await migration.close()
+
+    @pytest.mark.asyncio
+    async def test_check_migration_not_needed(self, tmp_path):
+        db_path = str(tmp_path / "test_journal.db")
+        create_legacy_database(db_path)
+
+        conn = sqlite3.connect(db_path)
+        conn.execute("ALTER TABLE journal_entries ADD COLUMN user_id TEXT NOT NULL DEFAULT 'default'")
+        conn.commit()
+        conn.close()
+
+        from web.migrations.migration_002_add_user_id import UserIdMigration
+        migration = UserIdMigration(db_path)
+        await migration.initialize()
+
+        assert await migration.check_migration_needed() is False
+        await migration.close()
+
+    @pytest.mark.asyncio
+    async def test_run_migration(self, tmp_path):
+        db_path = str(tmp_path / "test_journal.db")
+        create_legacy_database(db_path)
+
+        from web.migrations.migration_002_add_user_id import UserIdMigration
+        migration = UserIdMigration(db_path)
+        await migration.initialize()
+
+        result = await migration.run_migration()
+        assert result["success"] is True
+
+        columns = get_columns(db_path, "journal_entries")
+        assert "user_id" in columns
+        await migration.close()
+
+    @pytest.mark.asyncio
+    async def test_validate_migration(self, tmp_path):
+        db_path = str(tmp_path / "test_journal.db")
+        create_legacy_database(db_path)
+
+        from web.migrations.migration_002_add_user_id import UserIdMigration
+        migration = UserIdMigration(db_path)
+        await migration.initialize()
+        await migration.run_migration()
+
+        result = await migration.validate_migration()
+        assert result["valid"] is True
+        assert result["column_exists"] is True
+        assert result["all_rows_have_user_id"] is True
+        await migration.close()

--- a/web/database.py
+++ b/web/database.py
@@ -9,7 +9,7 @@ while maintaining the file system as the primary data store.
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase
-from sqlalchemy import Column, Integer, String, Date, Boolean, DateTime, Text, Float, Index, update
+from sqlalchemy import Column, Integer, String, Date, Boolean, DateTime, Text, Float, Index, update, text
 from datetime import datetime
 from .utils.timezone_utils import now_utc, now_local
 import aiosqlite
@@ -261,13 +261,35 @@ class DatabaseManager:
         # Create tables
         async with self.engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-            
+
+        # Apply schema migrations for columns added after initial release
+        await self._apply_schema_migrations()
+
         # Initialize default settings
         await self._initialize_default_settings()
-        
+
         # Initialize default work week settings
         await self._initialize_default_work_week_settings()
     
+    async def _apply_schema_migrations(self):
+        """Add columns that were introduced after the initial schema release."""
+        log = logging.getLogger(__name__)
+        async with self.engine.begin() as conn:
+            result = await conn.execute(text("PRAGMA table_info(journal_entries)"))
+            columns = [row[1] for row in result.fetchall()]
+
+            if "user_id" not in columns:
+                log.info("Migrating journal_entries: adding user_id column")
+                await conn.execute(text(
+                    "ALTER TABLE journal_entries "
+                    "ADD COLUMN user_id TEXT NOT NULL DEFAULT 'default'"
+                ))
+                await conn.execute(text(
+                    "CREATE INDEX IF NOT EXISTS ix_journal_entries_user_id "
+                    "ON journal_entries(user_id)"
+                ))
+                log.info("Migration complete: user_id column added")
+
     async def _initialize_default_settings(self):
         """Initialize default web settings."""
         default_settings = [

--- a/web/migrations/migration_002_add_user_id.py
+++ b/web/migrations/migration_002_add_user_id.py
@@ -1,0 +1,207 @@
+# ABOUTME: Database migration to add user_id column to journal_entries.
+# ABOUTME: Backfills existing rows with the "default" user_id value.
+"""
+Database Migration Script: Add user_id to journal_entries
+
+This migration adds the user_id column required for multi-user support.
+Existing rows are backfilled with user_id='default'.
+
+Migration: 002_add_user_id_to_journal_entries
+Created: 2026-05-26
+"""
+
+import asyncio
+import logging
+
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy import text
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class UserIdMigration:
+    """Handle adding user_id column to journal_entries."""
+
+    def __init__(self, database_path: str = None):
+        if database_path is None:
+            from web.database import DatabaseManager
+            dm = DatabaseManager()
+            self.database_path = dm.database_path
+        else:
+            self.database_path = database_path
+        self.engine = None
+        self.SessionLocal = None
+
+    async def initialize(self):
+        """Initialize database connection."""
+        self.engine = create_async_engine(
+            f"sqlite+aiosqlite:///{self.database_path}",
+            echo=False
+        )
+        self.SessionLocal = async_sessionmaker(
+            self.engine,
+            class_=AsyncSession,
+            expire_on_commit=False
+        )
+
+    async def check_migration_needed(self) -> bool:
+        """Check if migration is needed."""
+        try:
+            async with self.engine.begin() as conn:
+                result = await conn.execute(text("PRAGMA table_info(journal_entries)"))
+                columns = [row[1] for row in result.fetchall()]
+                return "user_id" not in columns
+        except Exception as e:
+            logger.error(f"Error checking migration status: {e}")
+            return True
+
+    async def run_migration(self) -> dict:
+        """Run the migration."""
+        migration_result = {
+            "success": False,
+            "column_added": False,
+            "index_created": False,
+            "errors": []
+        }
+
+        try:
+            async with self.engine.begin() as conn:
+                await conn.execute(text(
+                    "ALTER TABLE journal_entries "
+                    "ADD COLUMN user_id TEXT NOT NULL DEFAULT 'default'"
+                ))
+                migration_result["column_added"] = True
+                logger.info("Added user_id column to journal_entries")
+
+                await conn.execute(text(
+                    "CREATE INDEX IF NOT EXISTS ix_journal_entries_user_id "
+                    "ON journal_entries(user_id)"
+                ))
+                migration_result["index_created"] = True
+                logger.info("Created index on journal_entries.user_id")
+
+            migration_result["success"] = True
+            logger.info("Migration completed successfully")
+
+        except Exception as e:
+            logger.error(f"Migration failed: {e}")
+            migration_result["errors"].append(str(e))
+
+        return migration_result
+
+    async def rollback_migration(self) -> dict:
+        """Rollback the migration."""
+        rollback_result = {
+            "success": False,
+            "errors": []
+        }
+
+        try:
+            async with self.engine.begin() as conn:
+                await conn.execute(text(
+                    "DROP INDEX IF EXISTS ix_journal_entries_user_id"
+                ))
+                await conn.execute(text(
+                    "ALTER TABLE journal_entries DROP COLUMN user_id"
+                ))
+                logger.info("Rolled back user_id column from journal_entries")
+
+            rollback_result["success"] = True
+
+        except Exception as e:
+            logger.error(f"Rollback failed: {e}")
+            rollback_result["errors"].append(str(e))
+
+        return rollback_result
+
+    async def validate_migration(self) -> dict:
+        """Validate that migration was successful."""
+        validation_result = {
+            "valid": False,
+            "column_exists": False,
+            "all_rows_have_user_id": False,
+            "errors": []
+        }
+
+        try:
+            async with self.engine.begin() as conn:
+                result = await conn.execute(text("PRAGMA table_info(journal_entries)"))
+                columns = [row[1] for row in result.fetchall()]
+                validation_result["column_exists"] = "user_id" in columns
+
+                if validation_result["column_exists"]:
+                    result = await conn.execute(text(
+                        "SELECT COUNT(*) FROM journal_entries "
+                        "WHERE user_id IS NULL OR user_id = ''"
+                    ))
+                    null_count = result.scalar()
+                    validation_result["all_rows_have_user_id"] = null_count == 0
+
+                validation_result["valid"] = (
+                    validation_result["column_exists"]
+                    and validation_result["all_rows_have_user_id"]
+                )
+
+                if validation_result["valid"]:
+                    logger.info("Migration validation successful")
+                else:
+                    logger.warning("Migration validation failed: %s", validation_result)
+
+        except Exception as e:
+            logger.error(f"Migration validation failed: {e}")
+            validation_result["errors"].append(str(e))
+
+        return validation_result
+
+    async def close(self):
+        """Close database connection."""
+        if self.engine:
+            await self.engine.dispose()
+
+
+async def main():
+    """Run migration from command line."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Migration 002: Add user_id to journal_entries"
+    )
+    parser.add_argument("--database", default=None,
+                        help="Database file path (defaults to OS-standard location)")
+    parser.add_argument("--rollback", action="store_true",
+                        help="Rollback the migration")
+    parser.add_argument("--validate", action="store_true",
+                        help="Validate the migration")
+    parser.add_argument("--force", action="store_true",
+                        help="Force migration even if not needed")
+
+    args = parser.parse_args()
+
+    migration = UserIdMigration(args.database)
+    await migration.initialize()
+
+    try:
+        if args.rollback:
+            result = await migration.rollback_migration()
+            print(f"Rollback result: {result}")
+        elif args.validate:
+            result = await migration.validate_migration()
+            print(f"Validation result: {result}")
+        else:
+            if not args.force and not await migration.check_migration_needed():
+                print("Migration not needed - user_id column already exists")
+                return
+
+            result = await migration.run_migration()
+            print(f"Migration result: {result}")
+
+            validation = await migration.validate_migration()
+            print(f"Validation result: {validation}")
+
+    finally:
+        await migration.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Adds auto-migration in `DatabaseManager.initialize()` that detects the missing `user_id` column and adds it via `ALTER TABLE` on startup
- Adds standalone migration script `web/migrations/migration_002_add_user_id.py` following the existing `001` pattern
- Adds 8 tests covering both the auto-migration and standalone script

## Context
The auth feature (PR #129) added `user_id` to the `JournalEntryIndex` SQLAlchemy model but did not include a database migration. `Base.metadata.create_all` only creates new tables — it does not ALTER existing ones. Any database created before that commit is missing the column, causing `OperationalError: no such column: journal_entries.user_id` on every query.

## Test plan
- [x] 8 new tests pass (`pytest tests/test_migration_002_user_id.py -v`)
- [x] 232 existing tests pass, no regressions (1 pre-existing failure in `test_calendar_api_endpoints`)
- [x] Live test: pull branch on server, restart app, confirm auto-migration runs and queries succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)