### PR TITLE
Fix/jinja2 starlette compat

### DIFF
--- a/tests/test_template_rendering.py
+++ b/tests/test_template_rendering.py
@@ -1,0 +1,28 @@
+# ABOUTME: Tests that all template-based routes render without server errors.
+# ABOUTME: Catches Jinja2/Starlette API incompatibilities in TemplateResponse calls.
+
+import pytest
+
+
+class TestTemplateRoutes:
+    """Verify that every template route returns HTTP 200, not 500."""
+
+    def test_dashboard_renders(self, isolated_app_client):
+        response = isolated_app_client.get("/")
+        assert response.status_code == 200, f"Dashboard failed: {response.text[:200]}"
+
+    def test_entry_editor_renders(self, isolated_app_client):
+        response = isolated_app_client.get("/entry/2026-01-01")
+        assert response.status_code == 200, f"Entry editor failed: {response.text[:200]}"
+
+    def test_calendar_renders(self, isolated_app_client):
+        response = isolated_app_client.get("/calendar")
+        assert response.status_code == 200, f"Calendar failed: {response.text[:200]}"
+
+    def test_summarization_renders(self, isolated_app_client):
+        response = isolated_app_client.get("/summarize")
+        assert response.status_code == 200, f"Summarization failed: {response.text[:200]}"
+
+    def test_settings_renders(self, isolated_app_client):
+        response = isolated_app_client.get("/settings")
+        assert response.status_code == 200, f"Settings failed: {response.text[:200]}"

--- a/web/app.py
+++ b/web/app.py
@@ -218,7 +218,7 @@ templates = Jinja2Templates(directory=str(templates_dir))
 @app.get("/")
 async def dashboard(request: Request):
     """Dashboard - main entry point for the web interface."""
-    return templates.TemplateResponse("dashboard.html", {"request": request})
+    return templates.TemplateResponse(request, "dashboard.html")
 
 
 @app.get("/entry/{entry_date}")
@@ -231,8 +231,7 @@ async def entry_editor(request: Request, entry_date: str):
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM-DD")
     
-    return templates.TemplateResponse("entry_editor.html", {
-        "request": request,
+    return templates.TemplateResponse(request, "entry_editor.html", {
         "entry_date": entry_date
     })
 
@@ -240,19 +239,19 @@ async def entry_editor(request: Request, entry_date: str):
 @app.get("/calendar")
 async def calendar_view(request: Request):
     """Calendar view interface for browsing journal entries."""
-    return templates.TemplateResponse("calendar.html", {"request": request})
+    return templates.TemplateResponse(request, "calendar.html")
 
 
 @app.get("/summarize")
 async def summarization_page(request: Request):
     """Summarization interface for generating journal summaries."""
-    return templates.TemplateResponse("summarization.html", {"request": request})
+    return templates.TemplateResponse(request, "summarization.html")
 
 
 @app.get("/settings")
 async def settings_page(request: Request):
     """Settings management interface."""
-    return templates.TemplateResponse("settings.html", {"request": request})
+    return templates.TemplateResponse(request, "settings.html")
 
 
 @app.get("/api")
@@ -269,7 +268,7 @@ async def api_root():
 @app.get("/test")
 async def test_page(request: Request):
     """Test page for base templates and styling."""
-    return templates.TemplateResponse("test.html", {"request": request})
+    return templates.TemplateResponse(request, "test.html")
 
 
 @app.websocket("/ws")


### PR DESCRIPTION
All 6 TemplateResponse calls in web/app.py used the deprecated Starlette signature (name, {"request": ...}). Starlette 1.3+ expects (request, name, context). The old style passed a dict as the template name, causing TypeError: unhashable type 'dict' in Jinja2's LRU cache — every template route returned 500.