### PR TITLE
Fix/90 path traversal

### DIFF
--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -1,0 +1,142 @@
+# ABOUTME: Tests for path traversal protection on the validate-path endpoint.
+# ABOUTME: Verifies that filesystem probing is restricted to allowed directories.
+
+"""
+Tests for GH#90: Path traversal via filesystem validate-path endpoint.
+
+The /api/settings/filesystem/validate-path endpoint must restrict path
+validation and directory creation to allowed roots (user home directory).
+Paths outside the allowed roots must be rejected with HTTP 403.
+"""
+
+import pytest
+from pathlib import Path
+
+
+class TestPathTraversalProtection:
+    """Verify the validate-path endpoint blocks path traversal attacks."""
+
+    @pytest.fixture
+    def client(self, isolated_app_client):
+        yield isolated_app_client
+
+    # --- Paths outside allowed roots must be rejected ---
+
+    def test_rejects_etc_passwd_probe(self, client):
+        """Probing /etc/passwd must be blocked."""
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": "/etc/passwd"}
+        )
+        assert response.status_code == 403
+
+    def test_rejects_root_path(self, client):
+        """Probing / must be blocked."""
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": "/"}
+        )
+        assert response.status_code == 403
+
+    def test_rejects_var_log_probe(self, client):
+        """Probing /var/log must be blocked."""
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": "/var/log"}
+        )
+        assert response.status_code == 403
+
+    def test_rejects_dot_dot_traversal(self, client):
+        """Paths using ../ to escape the home directory must be blocked."""
+        home = str(Path.home())
+        # Attempt to traverse out of home via ../
+        traversal_path = home + "/../../../etc/passwd"
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": traversal_path}
+        )
+        assert response.status_code == 403
+
+    def test_rejects_relative_dot_dot_traversal(self, client):
+        """Relative paths with ../ that resolve outside home must be blocked."""
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": "../../../etc/passwd"}
+        )
+        assert response.status_code == 403
+
+    def test_rejects_create_outside_allowed_root(self, client):
+        """Creating directories outside allowed roots must be blocked."""
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": "/tmp/evil_directory", "create_if_missing": True}
+        )
+        assert response.status_code == 403
+
+    # --- Paths inside allowed roots must be permitted ---
+
+    def test_allows_home_subdirectory(self, client):
+        """Paths under the user's home directory are allowed."""
+        home = str(Path.home())
+        safe_path = home + "/Desktop/worklogs"
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": safe_path}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "path" in data
+        assert "exists" in data
+
+    def test_allows_home_with_tilde(self, client):
+        """Paths using ~ shorthand should be expanded and allowed."""
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": "~/Desktop/worklogs"}
+        )
+        assert response.status_code == 200
+
+    def test_allows_create_inside_home(self, client, tmp_path):
+        """Creating directories inside the home dir should work."""
+        # Use a path under home that we can safely create
+        home = str(Path.home())
+        test_path = home + "/test_wjm_validate_path_creation"
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": test_path, "create_if_missing": True}
+        )
+        # Clean up if created
+        created = Path(test_path)
+        if created.exists():
+            created.rmdir()
+        assert response.status_code == 200
+        data = response.json()
+        assert data["exists"] is True
+        assert data["is_directory"] is True
+
+    # --- Response must not leak sensitive path info ---
+
+    def test_response_excludes_absolute_path_field(self, client):
+        """The response must not include a separate absolute_path field."""
+        home = str(Path.home())
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": home}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # absolute_path is redundant info leakage; only 'path' should be present
+        assert "absolute_path" not in data
+
+    # --- Error message must not reveal filesystem details ---
+
+    def test_rejection_message_is_generic(self, client):
+        """Rejected paths must get a generic error, not reveal path details."""
+        response = client.get(
+            "/api/settings/filesystem/validate-path",
+            params={"path": "/etc/shadow"}
+        )
+        assert response.status_code == 403
+        data = response.json()
+        # Should not echo back the probed path
+        assert "/etc/shadow" not in data.get("detail", "")

--- a/todo.md
+++ b/todo.md
@@ -24,7 +24,7 @@ Full design: [docs/superpowers/specs/2026-05-08-issue-triage-design.md](docs/sup
 - [x] [#89](https://github.com/lbnl-science-it/WorkJournalMaker/issues/89) — No CSRF protection on state-changing API calls
 
 ### High
-- [ ] [#90](https://github.com/lbnl-science-it/WorkJournalMaker/issues/90) — Path traversal via validate-path endpoint
+- [x] [#90](https://github.com/lbnl-science-it/WorkJournalMaker/issues/90) — Path traversal via validate-path endpoint
 - [ ] [#91](https://github.com/lbnl-science-it/WorkJournalMaker/issues/91) — No security response headers
 - [ ] [#92](https://github.com/lbnl-science-it/WorkJournalMaker/issues/92) — CDN script without Subresource Integrity
 - [ ] [#93](https://github.com/lbnl-science-it/WorkJournalMaker/issues/93) — Unescaped data in inline onclick attributes

--- a/web/api/settings.py
+++ b/web/api/settings.py
@@ -573,6 +573,16 @@ async def import_settings(
             detail=f"Failed to import settings: {str(e)}"
         )
 
+def _is_path_within_allowed_roots(resolved_path: Path, allowed_roots: list) -> bool:
+    """Check whether resolved_path falls under at least one allowed root."""
+    resolved_str = str(resolved_path)
+    for root in allowed_roots:
+        root_str = str(root)
+        if resolved_str == root_str or resolved_str.startswith(root_str + "/"):
+            return True
+    return False
+
+
 @router.get("/filesystem/validate-path")
 async def validate_filesystem_path(
     path: str,
@@ -580,20 +590,32 @@ async def validate_filesystem_path(
     settings_service: SettingsService = Depends(get_settings_service),
     user: User = Depends(get_current_user)
 ):
-    """Validate a filesystem path and optionally create it."""
+    """Validate a filesystem path and optionally create it.
+
+    Restricted to paths under the user's home directory to prevent
+    arbitrary filesystem probing or directory creation.
+    """
     try:
         from pathlib import Path
-        
-        path_obj = Path(path)
-        
-        # Check if path is absolute or make it relative to current working directory
+
+        # Expand ~ and resolve to canonical absolute path
+        path_obj = Path(path).expanduser()
         if not path_obj.is_absolute():
-            path_obj = Path.cwd() / path_obj
-        
+            path_obj = Path.home() / path_obj
+        path_obj = path_obj.resolve()
+
+        # Restrict to allowed roots (user's home directory)
+        allowed_roots = [Path.home().resolve()]
+        if not _is_path_within_allowed_roots(path_obj, allowed_roots):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Path is outside the allowed directory"
+            )
+
         exists = path_obj.exists()
         is_directory = path_obj.is_dir() if exists else None
         is_writable = None
-        
+
         if exists:
             try:
                 # Test write permissions
@@ -601,7 +623,7 @@ async def validate_filesystem_path(
                 test_file.touch()
                 test_file.unlink()
                 is_writable = True
-            except:
+            except Exception:
                 is_writable = False
         elif create_if_missing:
             try:
@@ -611,27 +633,26 @@ async def validate_filesystem_path(
                 is_writable = True
                 settings_service.logger.logger.info(f"Created directory: {path_obj}")
             except Exception as e:
-                settings_service.logger.logger.error(f"Failed to create directory {path_obj}: {str(e)}")
+                settings_service.logger.logger.error(f"Failed to create directory: {str(e)}")
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Cannot create directory: {str(e)}"
+                    detail="Cannot create directory at the specified path"
                 )
-        
+
         return {
             "path": str(path_obj),
             "exists": exists,
             "is_directory": is_directory,
             "is_writable": is_writable,
-            "absolute_path": str(path_obj.absolute())
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        settings_service.logger.logger.error(f"Failed to validate path {path}: {str(e)}")
+        settings_service.logger.logger.error(f"Failed to validate path: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid path: {str(e)}"
+            detail="Invalid path"
         )
 
 


### PR DESCRIPTION
## Summary

  - Add path canonicalization and home-directory restriction to `/api/settings/filesystem/validate-path` endpoint
  - Block arbitrary filesystem probing (`/etc/passwd`, `/var/log`, etc.) and directory creation outside the user's home directory
  - Remove redundant `absolute_path` field from response to prevent information disclosure
  - Return HTTP 403 with generic error message for disallowed paths (no path echo)

  ## Test plan

  - [x] Paths outside home dir return 403 (`/etc/passwd`, `/`, `/var/log`)
  - [x] `../` traversal sequences that escape home dir are blocked
  - [x] `create_if_missing=true` outside allowed roots is blocked
  - [x] Paths within home dir (absolute and `~` shorthand) still work
  - [x] Directory creation within home dir still works
  - [x] Response no longer includes `absolute_path` field
  - [x] Rejection error messages do not echo the probed path
  - [x] No regressions across 109 existing tests

  🤖 Generated with [Claude Code](https://claude.com/claude-code)