### PR TITLE
Fix/93 inline onclick

### DIFF
--- a/tests/test_inline_onclick.py
+++ b/tests/test_inline_onclick.py
@@ -1,0 +1,70 @@
+# ABOUTME: Tests that verify no inline onclick handlers with dynamic data exist.
+# ABOUTME: Ensures JS files use addEventListener instead of onclick attributes.
+
+"""
+Tests for GH#93: Unescaped data in inline onclick attributes.
+
+Inline onclick handlers with template-interpolated data are DOM XSS vectors.
+All dynamic event handlers must use addEventListener or data-attribute
+delegation instead.
+"""
+
+import pytest
+from pathlib import Path
+
+# JS files that previously contained dynamic onclick handlers
+JS_FILES = [
+    "web/static/js/dashboard.js",
+    "web/static/js/calendar.js",
+    "web/static/js/summarization.js",
+    "web/static/js/settings.js",
+    "web/static/js/utils.js",
+]
+
+# Template files that previously contained inline onclick handlers
+TEMPLATE_FILES = [
+    "web/templates/entry_editor.html",
+    "web/templates/test.html",
+]
+
+ALL_FILES = JS_FILES + TEMPLATE_FILES
+
+
+class TestNoInlineOnclick:
+    """Verify no onclick attributes remain in JS or template files."""
+
+    @pytest.mark.parametrize("filepath", ALL_FILES)
+    def test_no_onclick_in_file(self, filepath):
+        """No file should contain onclick= attributes."""
+        path = Path(filepath)
+        assert path.exists(), f"{filepath} not found"
+        content = path.read_text()
+        # Search for onclick= (with either single or double quotes)
+        assert 'onclick="' not in content, (
+            f"{filepath} contains onclick=\" attribute"
+        )
+        assert "onclick='" not in content, (
+            f"{filepath} contains onclick=' attribute"
+        )
+
+
+class TestEventDelegationPresent:
+    """Verify that addEventListener-based handlers replaced inline onclick."""
+
+    def _read(self, filepath):
+        return Path(filepath).read_text()
+
+    def test_dashboard_uses_event_delegation(self):
+        """dashboard.js should use click event delegation for entry items."""
+        content = self._read("web/static/js/dashboard.js")
+        assert "addEventListener" in content or "click" in content
+
+    def test_calendar_uses_event_delegation(self):
+        """calendar.js should use click event delegation for date cells."""
+        content = self._read("web/static/js/calendar.js")
+        assert "addEventListener" in content
+
+    def test_summarization_uses_event_delegation(self):
+        """summarization.js should use click event delegation for history actions."""
+        content = self._read("web/static/js/summarization.js")
+        assert "addEventListener" in content

--- a/todo.md
+++ b/todo.md
@@ -27,7 +27,7 @@ Full design: [docs/superpowers/specs/2026-05-08-issue-triage-design.md](docs/sup
 - [x] [#90](https://github.com/lbnl-science-it/WorkJournalMaker/issues/90) — Path traversal via validate-path endpoint
 - [x] [#91](https://github.com/lbnl-science-it/WorkJournalMaker/issues/91) — No security response headers
 - [x] [#92](https://github.com/lbnl-science-it/WorkJournalMaker/issues/92) — CDN script without Subresource Integrity
-- [ ] [#93](https://github.com/lbnl-science-it/WorkJournalMaker/issues/93) — Unescaped data in inline onclick attributes
+- [x] [#93](https://github.com/lbnl-science-it/WorkJournalMaker/issues/93) — Unescaped data in inline onclick attributes
 
 ### Medium
 - [ ] [#94](https://github.com/lbnl-science-it/WorkJournalMaker/issues/94) — Prompt injection via unsanitized journal content

--- a/todo.md
+++ b/todo.md
@@ -26,7 +26,7 @@ Full design: [docs/superpowers/specs/2026-05-08-issue-triage-design.md](docs/sup
 ### High
 - [x] [#90](https://github.com/lbnl-science-it/WorkJournalMaker/issues/90) — Path traversal via validate-path endpoint
 - [x] [#91](https://github.com/lbnl-science-it/WorkJournalMaker/issues/91) — No security response headers
-- [ ] [#92](https://github.com/lbnl-science-it/WorkJournalMaker/issues/92) — CDN script without Subresource Integrity
+- [x] [#92](https://github.com/lbnl-science-it/WorkJournalMaker/issues/92) — CDN script without Subresource Integrity
 - [ ] [#93](https://github.com/lbnl-science-it/WorkJournalMaker/issues/93) — Unescaped data in inline onclick attributes
 
 ### Medium

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -40,7 +40,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
         "Content-Security-Policy": (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "script-src 'self' https://cdn.jsdelivr.net; "
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self'; "
             "font-src 'self'; "

--- a/web/static/js/calendar.js
+++ b/web/static/js/calendar.js
@@ -115,10 +115,9 @@ class CalendarView {
                 }
 
                 html += `
-                    <div class="${cssClasses.join(' ')}" 
+                    <div class="${cssClasses.join(' ')}"
                          data-date="${dateStr}"
-                         data-day="${dayNumber}"
-                         onclick="calendar.selectDate('${dateStr}')">
+                         data-day="${dayNumber}">
                         ${dayNumber}
                     </div>
                 `;
@@ -153,7 +152,7 @@ class CalendarView {
         }
 
         container.innerHTML = this.recentEntries.map(entry => `
-            <div class="recent-item" onclick="calendar.selectDate('${Utils.escapeHtml(entry.date)}')">
+            <div class="recent-item" data-date="${Utils.escapeHtml(entry.date)}">
                 <div class="recent-date">${Utils.escapeHtml(Utils.formatDate(Utils.parseDate(entry.date), 'short'))}</div>
                 <div class="recent-preview">${Utils.escapeHtml(this.getEntryPreview(entry))}</div>
             </div>
@@ -236,6 +235,18 @@ class CalendarView {
         // Close preview button
         document.getElementById('close-preview-btn').addEventListener('click', () => {
             this.closePreview();
+        });
+
+        // Delegate clicks on calendar day cells
+        document.getElementById('calendar-grid')?.addEventListener('click', (e) => {
+            const cell = e.target.closest('[data-date]');
+            if (cell) this.selectDate(cell.dataset.date);
+        });
+
+        // Delegate clicks on recent entry items
+        document.getElementById('recent-list')?.addEventListener('click', (e) => {
+            const item = e.target.closest('.recent-item[data-date]');
+            if (item) this.selectDate(item.dataset.date);
         });
 
         // Edit entry button

--- a/web/static/js/dashboard.js
+++ b/web/static/js/dashboard.js
@@ -120,7 +120,7 @@ class Dashboard {
         }
 
         container.innerHTML = this.recentEntries.map(entry => `
-      <div class="entry-item" data-date="${Utils.escapeHtml(entry.date)}" onclick="Dashboard.openEntry('${Utils.escapeHtml(entry.date)}')">
+      <div class="entry-item" data-date="${Utils.escapeHtml(entry.date)}">
         <div class="entry-info">
           <div class="entry-date">${Utils.escapeHtml(Utils.formatDate(Utils.parseDate(entry.date), 'short'))}</div>
           <div class="entry-preview">${Utils.escapeHtml(this.getEntryPreview(entry))}</div>
@@ -218,6 +218,12 @@ class Dashboard {
         document.getElementById('search-action')?.addEventListener('click', () => {
             // Implement search functionality
             Utils.showToast('Search functionality coming soon!', 'info');
+        });
+
+        // Delegate clicks on recent entry items
+        document.getElementById('recent-entries')?.addEventListener('click', (e) => {
+            const item = e.target.closest('.entry-item[data-date]');
+            if (item) Dashboard.openEntry(item.dataset.date);
         });
     }
 

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -154,6 +154,11 @@ class JournalEditor {
                 this.showKeyboardShortcuts();
             }
         });
+
+        // Close shortcuts help panel
+        document.getElementById('close-shortcuts-btn')?.addEventListener('click', () => {
+            document.getElementById('shortcuts-help').style.display = 'none';
+        });
     }
 
     setupAutoSave() {

--- a/web/static/js/settings.js
+++ b/web/static/js/settings.js
@@ -1565,6 +1565,16 @@ class SyncManager {
         document.getElementById('full-sync-days')?.addEventListener('input', (e) => {
             this.validateDaysInput(e.target, 30, 3650);
         });
+
+        // Delegate clicks on scheduler control buttons
+        document.getElementById('sync-scheduler-content')?.addEventListener('click', (e) => {
+            const btn = e.target.closest('[data-action]');
+            if (!btn) return;
+            const action = btn.dataset.action;
+            if (action === 'start-scheduler') this.startScheduler();
+            else if (action === 'stop-scheduler') this.stopScheduler();
+            else if (action === 'trigger-sync') this.triggerSchedulerSync(btn.dataset.syncType);
+        });
     }
 
     validateDaysInput(input, min, max) {
@@ -1769,15 +1779,15 @@ class SyncManager {
                     </div>
                 </div>
                 <div class="scheduler-controls">
-                    <button class="btn btn-${isRunning ? 'secondary' : 'primary'} btn-small" 
-                            onclick="syncManager.${isRunning ? 'stopScheduler' : 'startScheduler'}()">
+                    <button class="btn btn-${isRunning ? 'secondary' : 'primary'} btn-small"
+                            data-action="${isRunning ? 'stop-scheduler' : 'start-scheduler'}">
                         ${isRunning ? 'Stop' : 'Start'} Scheduler
                     </button>
                     ${isRunning ? `
-                        <button class="btn btn-secondary btn-small" onclick="syncManager.triggerSchedulerSync('incremental')">
+                        <button class="btn btn-secondary btn-small" data-action="trigger-sync" data-sync-type="incremental">
                             Trigger Incremental
                         </button>
-                        <button class="btn btn-secondary btn-small" onclick="syncManager.triggerSchedulerSync('full')">
+                        <button class="btn btn-secondary btn-small" data-action="trigger-sync" data-sync-type="full">
                             Trigger Full
                         </button>
                     ` : ''}

--- a/web/static/js/summarization.js
+++ b/web/static/js/summarization.js
@@ -56,6 +56,15 @@ class SummarizationInterface {
             this.loadSummaryHistory();
         });
 
+        // Delegate clicks on history action buttons
+        document.getElementById('history-container')?.addEventListener('click', (e) => {
+            const btn = e.target.closest('[data-action]');
+            if (!btn) return;
+            const taskId = btn.dataset.taskId;
+            if (btn.dataset.action === 'view') this.viewHistoryItem(taskId);
+            else if (btn.dataset.action === 'download') this.downloadHistoryItem(taskId);
+        });
+
         // Close modals on overlay click
         document.getElementById('progress-modal').addEventListener('click', (e) => {
             if (e.target === e.currentTarget) {
@@ -517,11 +526,11 @@ class SummarizationInterface {
           ${Utils.escapeHtml(this.getHistoryPreview(summary))}
         </div>
         <div class="history-actions">
-          <button class="btn btn-secondary btn-sm" onclick="summarizationInterface.viewHistoryItem('${Utils.escapeHtml(summary.task_id)}')">
+          <button class="btn btn-secondary btn-sm" data-action="view" data-task-id="${Utils.escapeHtml(summary.task_id)}">
             View
           </button>
           ${summary.status === 'completed' ? `
-            <button class="btn btn-secondary btn-sm" onclick="summarizationInterface.downloadHistoryItem('${Utils.escapeHtml(summary.task_id)}')">
+            <button class="btn btn-secondary btn-sm" data-action="download" data-task-id="${Utils.escapeHtml(summary.task_id)}">
               Download
             </button>
           ` : ''}

--- a/web/static/js/test-page.js
+++ b/web/static/js/test-page.js
@@ -1,0 +1,46 @@
+// ABOUTME: Event handlers for the test/debug page (test.html).
+// ABOUTME: Provides toast, loading, keyboard shortcut, and theme change demos.
+
+function testToast(type) {
+    const messages = {
+        success: 'Operation completed successfully!',
+        error: 'Something went wrong. Please try again.',
+        warning: 'Please review your input before proceeding.',
+        info: 'Here is some helpful information.'
+    };
+
+    Utils.showToast(messages[type] || 'Test message', type);
+}
+
+function testLoading() {
+    const btn = document.getElementById('loading-btn');
+    Utils.setLoading(btn, true);
+
+    setTimeout(() => {
+        Utils.setLoading(btn, false);
+        Utils.showToast('Loading test completed!', 'success');
+    }, 3000);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Toast test buttons
+    document.querySelectorAll('[data-toast]').forEach(btn => {
+        btn.addEventListener('click', () => testToast(btn.dataset.toast));
+    });
+
+    // Loading test button
+    document.getElementById('loading-btn')?.addEventListener('click', testLoading);
+
+    // Test keyboard shortcuts
+    document.addEventListener('keydown', (e) => {
+        if (Utils.keyboard.isCombo(e, 'ctrl+k')) {
+            e.preventDefault();
+            Utils.showToast('Keyboard shortcut Ctrl+K detected!', 'info');
+        }
+    });
+
+    // Test theme change event
+    window.addEventListener('themechange', (e) => {
+        Utils.showToast(`Theme changed to ${e.detail.theme}`, 'info', 2000);
+    });
+});

--- a/web/static/js/utils.js
+++ b/web/static/js/utils.js
@@ -68,7 +68,7 @@ class Utils {
         toast.innerHTML = `
       <div class="toast-icon">${icon}</div>
       <div class="toast-content">${Utils.escapeHtml(message)}</div>
-      <button class="toast-close" onclick="this.parentElement.remove()" aria-label="Close notification">
+      <button class="toast-close" aria-label="Close notification">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
           <line x1="18" y1="6" x2="6" y2="18" stroke="currentColor" stroke-width="2"/>
           <line x1="6" y1="6" x2="18" y2="18" stroke="currentColor" stroke-width="2"/>
@@ -77,6 +77,8 @@ class Utils {
     `;
 
         container.appendChild(toast);
+
+        toast.querySelector('.toast-close')?.addEventListener('click', () => toast.remove());
 
         // Auto-remove after duration
         if (duration > 0) {

--- a/web/templates/entry_editor.html
+++ b/web/templates/entry_editor.html
@@ -191,8 +191,7 @@
                 <span>Preview</span>
             </div>
         </div>
-        <button class="btn btn-secondary"
-            onclick="document.getElementById('shortcuts-help').style.display='none'">Close</button>
+        <button class="btn btn-secondary" id="close-shortcuts-btn">Close</button>
     </div>
 </div>
 {% endblock %}

--- a/web/templates/test.html
+++ b/web/templates/test.html
@@ -11,10 +11,10 @@
 
         <!-- Theme Toggle Test -->
         <div class="d-flex gap-4 mb-6">
-            <button class="btn btn-primary" onclick="testToast('success')">Test Success Toast</button>
-            <button class="btn btn-secondary" onclick="testToast('error')">Test Error Toast</button>
-            <button class="btn btn-ghost" onclick="testToast('warning')">Test Warning Toast</button>
-            <button class="btn btn-primary btn-sm" onclick="testToast('info')">Test Info Toast</button>
+            <button class="btn btn-primary" data-toast="success">Test Success Toast</button>
+            <button class="btn btn-secondary" data-toast="error">Test Error Toast</button>
+            <button class="btn btn-ghost" data-toast="warning">Test Warning Toast</button>
+            <button class="btn btn-primary btn-sm" data-toast="info">Test Info Toast</button>
         </div>
     </section>
 
@@ -89,7 +89,7 @@ function hello() {
 
                 <div class="d-flex gap-3">
                     <button class="btn btn-primary" disabled>Disabled Button</button>
-                    <button class="btn btn-primary loading" id="loading-btn" onclick="testLoading()">Test
+                    <button class="btn btn-primary loading" id="loading-btn">Test
                         Loading</button>
                 </div>
             </div>
@@ -285,39 +285,5 @@ function hello() {
 {% endblock %}
 
 {% block extra_js %}
-<script>
-    function testToast(type) {
-        const messages = {
-            success: 'Operation completed successfully!',
-            error: 'Something went wrong. Please try again.',
-            warning: 'Please review your input before proceeding.',
-            info: 'Here is some helpful information.'
-        };
-
-        Utils.showToast(messages[type] || 'Test message', type);
-    }
-
-    function testLoading() {
-        const btn = document.getElementById('loading-btn');
-        Utils.setLoading(btn, true);
-
-        setTimeout(() => {
-            Utils.setLoading(btn, false);
-            Utils.showToast('Loading test completed!', 'success');
-        }, 3000);
-    }
-
-    // Test keyboard shortcuts
-    document.addEventListener('keydown', function (e) {
-        if (Utils.keyboard.isCombo(e, 'ctrl+k')) {
-            e.preventDefault();
-            Utils.showToast('Keyboard shortcut Ctrl+K detected!', 'info');
-        }
-    });
-
-    // Test theme change event
-    window.addEventListener('themechange', function (e) {
-        Utils.showToast(`Theme changed to ${e.detail.theme}`, 'info', 2000);
-    });
-</script>
+<script src="/static/js/test-page.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

  - Replace all inline `onclick` attributes with `addEventListener` and data-attribute delegation across 7 files
  - Move test.html inline script to external `test-page.js`
  - Tighten CSP by removing `'unsafe-inline'` from `script-src` now that no inline JS remains

  Fixes #93

  ## Test plan

  - [x] No `onclick=` attributes remain in any JS or template file (7 files checked)
  - [x] addEventListener-based delegation present in dashboard, calendar, summarization
  - [x] Toast close buttons work via addEventListener
  - [x] Editor shortcuts panel close works via addEventListener
  - [x] CSP no longer permits unsafe-inline scripts
  - [x] No regressions across 117 tests

  🤖 Generated with [Claude Code](https://claude.com/claude-code)