### PR TITLE
Fix/96 information disclosure

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,142 +1,229 @@
-# Fix Pre-existing Test Failures — Issue #60 Plan
+# Plan: Fix Information Disclosure Vulnerability (Chainlink #17 / GH#96)
 
-**Issue:** [#60](https://github.com/lbnl-science-it/WorkJournalMaker/issues/60)
-**Branch:** `fix/issue-60-test-failures`
-**Baseline:** 54 failed + 18 errors = 72 broken tests across 11 files (in scope)
-**Full suite baseline:** 169 failed, 1349 passed, 27 errors
+## Context
+
+Multiple API endpoints leak internal details through raw exception strings in HTTP responses, filesystem paths in health checks, and LLM configuration in diagnostic endpoints. This is OWASP A05:2021 (Security Misconfiguration). Attackers can use leaked paths, provider names, and DB errors for reconnaissance.
+
+**Design Decisions:**
+- **Inline generic strings** for `HTTPException.detail` (matching existing safe pattern in `web/api/entries.py`) — no utility function needed for these
+- **One small utility** `sanitize_error_message()` for the DB-stored `error_message` column read in two places
+- **Health endpoint stays public** but stripped of internal detail; `/config` and `/metrics` stay admin-gated
+- **Sync error_message sanitized on both read AND write** — defense in depth
+- **`bulk_update` ValueError block** — replace `str(ve)` with static message; ConnectionError and TimeoutError blocks already safe
 
 ---
 
-## Phase 1: Async Fixture Decorator Fixes
+## Phase 1: Create `web/utils/error_utils.py`
 
-**Goal:** Fix the 37 failures + 18 errors caused by `@pytest.fixture` on `async def` functions.
-**Risk:** Low — mechanical decorator swaps.
-**Scope:** 7 test files, ~26 async fixtures to swap.
+**Why:** The sync `error_message` column is read in two places (`get_sync_status()` and `GET /api/sync/history`). A tiny shared function avoids duplication.
 
-### Step 1.1: Fix work_week async test fixtures — [#73](https://github.com/lbnl-science-it/WorkJournalMaker/issues/73)
+**New file:** `web/utils/error_utils.py`
+- `sanitize_error_message(raw: str | None, *, generic: str = "An error occurred") -> str | None`
+- Returns `None` when `raw is None`, otherwise returns `generic`
 
-**Files:** `tests/test_work_week_compatibility.py`, `tests/test_work_week_database_sync.py`, `tests/test_work_week_integration.py`, `tests/test_work_week_performance.py`
-**What:** Replace `@pytest.fixture` with `@pytest_asyncio.fixture` on all async fixtures. Add `import pytest_asyncio` where missing.
-**Verification:** Run these 4 files — failures should drop significantly.
-
-```text
-Fix async fixture decorators in the work week test files for issue #60.
-
-In pytest-asyncio strict mode, async fixtures must use @pytest_asyncio.fixture
-instead of @pytest.fixture, otherwise sync test functions receive coroutine
-objects instead of resolved values.
-
-Files to fix:
-1. tests/test_work_week_compatibility.py — 2 async fixtures need decorator swap, add import pytest_asyncio
-2. tests/test_work_week_database_sync.py — 5 async fixtures need decorator swap, add import pytest_asyncio
-3. tests/test_work_week_integration.py — check for async fixtures, add import pytest_asyncio if needed
-4. tests/test_work_week_performance.py — 2 async fixtures need decorator swap (pytest_asyncio already imported)
-
-For each file:
-1. Find all fixtures defined with `@pytest.fixture` and `async def`
-2. Replace `@pytest.fixture` with `@pytest_asyncio.fixture` on those fixtures
-3. Add `import pytest_asyncio` at the top if not already present
-4. Do NOT change any test logic, assertions, or non-fixture code
-
-After fixes, run:
-  pytest tests/test_work_week_compatibility.py tests/test_work_week_database_sync.py \
-    tests/test_work_week_integration.py tests/test_work_week_performance.py --tb=short -q
-
-Commit: "Fix async fixture decorators in work week tests (#60, step 1.1)"
-```
-
-### Step 1.2: Fix calendar async test fixtures — [#74](https://github.com/lbnl-science-it/WorkJournalMaker/issues/74)
-
-**Files:** `tests/test_calendar_interface_step14.py`, `tests/test_calendar_service_integration.py`
-**What:** Same decorator swap pattern. These files also have setup/teardown errors (Category 3) that should resolve.
-**Verification:** Run these 2 files — expect errors to resolve.
+**Test file:** `tests/test_error_utils.py`
+- `test_sanitize_none_returns_none`
+- `test_sanitize_non_none_returns_generic`
+- `test_sanitize_custom_generic`
+- `test_sanitize_empty_string_returns_generic`
 
 ```text
-Fix async fixture decorators in the calendar test files for issue #60.
+Write failing tests for a new utility function `sanitize_error_message` in `web/utils/error_utils.py`.
 
-Same root cause as step 1.1: async fixtures using @pytest.fixture instead of
-@pytest_asyncio.fixture in strict mode.
+The function signature: `sanitize_error_message(raw: str | None, *, generic: str = "An error occurred") -> str | None`
+- Returns None when raw is None
+- Returns the generic message for any non-None input (including empty string)
+- Accepts a custom generic keyword argument
 
-Files to fix:
-1. tests/test_calendar_interface_step14.py — 5 async fixtures need decorator swap, add import pytest_asyncio
-2. tests/test_calendar_service_integration.py — 7 async fixtures need decorator swap, add import pytest_asyncio
-
-For each file:
-1. Find all fixtures defined with `@pytest.fixture` and `async def`
-2. Replace `@pytest.fixture` with `@pytest_asyncio.fixture` on those fixtures
-3. Add `import pytest_asyncio` at the top if not already present
-4. Do NOT change any test logic, assertions, or non-fixture code
-
-After fixes, run:
-  pytest tests/test_calendar_interface_step14.py tests/test_calendar_service_integration.py --tb=short -q
-
-Commit: "Fix async fixture decorators in calendar tests (#60, step 1.2)"
-```
-
-### Step 1.3: Fix web integration async test fixtures — [#75](https://github.com/lbnl-science-it/WorkJournalMaker/issues/75)
-
-**Files:** `tests/test_web_integration.py`
-**What:** Same decorator swap pattern. 5 async fixtures + setup/teardown errors.
-**Verification:** Run this file — expect errors to resolve.
-
-```text
-Fix async fixture decorators in the web integration test file for issue #60.
-
-Same root cause as steps 1.1 and 1.2.
-
-File to fix:
-1. tests/test_web_integration.py — 5 async fixtures need decorator swap, add import pytest_asyncio
-
-Steps:
-1. Find all fixtures defined with `@pytest.fixture` and `async def`
-2. Replace `@pytest.fixture` with `@pytest_asyncio.fixture` on those fixtures
-3. Add `import pytest_asyncio` at the top if not already present
-4. Do NOT change any test logic, assertions, or non-fixture code
-
-After fixes, run:
-  pytest tests/test_web_integration.py --tb=short -q
-
-Commit: "Fix async fixture decorators in web integration tests (#60, step 1.3)"
-```
-
-### Step 1.4: Phase 1 verification and decision gate
-
-**What:** Run all 7 files together. Record results. Decide whether Phase 2 is worth pursuing.
-
-```text
-Run the full Phase 1 verification for issue #60.
-
-Run all 7 async-fixture-affected files together:
-  pytest tests/test_work_week_compatibility.py tests/test_work_week_database_sync.py \
-    tests/test_work_week_integration.py tests/test_work_week_performance.py \
-    tests/test_calendar_interface_step14.py tests/test_calendar_service_integration.py \
-    tests/test_web_integration.py --tb=short -q
-
-Baseline was: 37 failed + 18 errors = 55 broken tests.
-Expected: Most or all should now pass.
-
-Record the results. This is a DECISION GATE:
-- If most tests pass: the test authors got the logic right, just the decorators
-  wrong. Phase 2 contract fixes are likely worth doing.
-- If most tests STILL FAIL with new errors: the tests were poorly written
-  end-to-end. Phase 2 should be reconsidered — deleting and rewriting may be
-  more appropriate than patching.
-
-Do NOT change production code. Only fix test wiring issues.
-
-Commit: "Verify Phase 1 async fixture fixes (#60, step 1.4)" (if any additional fixes needed)
+Create `tests/test_error_utils.py` with four test cases covering: None input, non-None input,
+custom generic kwarg, and empty string. Use plain pytest (no async needed).
+Run the tests to confirm they fail. Then create `web/utils/error_utils.py` with the ABOUTME header
+and the function implementation. Run tests again to confirm they pass.
+Update `web/utils/__init__.py` to re-export `sanitize_error_message`.
 ```
 
 ---
 
-## Decision Gate: Result
+## Phase 2: Fix `web/api/health.py` (unauthenticated endpoint info leak)
 
-**Recovery rate: 11%** (6 of 55 broken tests). Below the 50% threshold.
+**Why:** `GET /api/health/` has no auth and exposes `base_path`, `database_path`, `llm_provider`.
 
-Findings:
-- Only 2 of 7 files had async fixture decorator issues (the original spec was wrong)
-- Remaining failures: stale API signatures, removed model columns, fixture scoping bugs
-- Tests were never validated against production code
+**Changes to `web/api/health.py`:**
+- Strip `components` dict to status-only for each component:
+  - `"database"` → `{"status": db_health["status"]}`
+  - `"filesystem"` → `{"status": "healthy" if fs_accessible else "unhealthy"}`
+  - `"configuration"` → `{"status": "healthy" if config else "unhealthy"}`
+- `/api/health/config` and `/api/health/metrics` — leave as-is (admin-gated)
 
-**Decision: Do not proceed with Phase 2.** Issues #76-80 closed.
-Filed [#81](https://github.com/lbnl-science-it/WorkJournalMaker/issues/81) to write proper test coverage from scratch.
+**Test file:** `tests/test_health_disclosure.py`
+- Assert `GET /api/health/` response contains no `base_path`, `database_path`, or `llm_provider` anywhere in JSON
+- Assert required fields `["status", "service", "version", "timestamp"]` still present
+
+```text
+Write failing tests in `tests/test_health_disclosure.py` for the public health endpoint.
+
+Use the `isolated_app_client` fixture from conftest.py. Write tests that:
+1. GET /api/health/ and assert "base_path" does NOT appear anywhere in response JSON (use json.dumps and string search)
+2. GET /api/health/ and assert "database_path" does NOT appear anywhere in response JSON
+3. GET /api/health/ and assert "llm_provider" does NOT appear anywhere in response JSON
+4. GET /api/health/ and assert required fields ["status", "service", "version", "timestamp"] ARE present
+5. GET /api/health/ and assert each component in "components" only has a "status" key
+
+Run tests to confirm they fail. Then modify `web/api/health.py` lines 40-57:
+- Change "database" component to: {"status": db_health["status"]}
+- Change "filesystem" component to: {"status": "healthy" if fs_accessible else "unhealthy"}
+- Change "configuration" component to: {"status": "healthy" if config else "unhealthy"}
+Run tests to confirm they pass. Run the existing health tests to confirm no regressions.
+```
+
+---
+
+## Phase 3: Fix `web/database.py` (health_check and get_database_stats)
+
+**Why:** `health_check()` returns `database_path` and `str(e)`. `get_database_stats()` returns `str(e)`.
+
+**Changes to `web/database.py`:**
+- `health_check()` healthy branch (line ~514): remove `"database_path"` key
+- `health_check()` unhealthy branch (line ~521): remove `"error"` and `"database_path"` keys
+- `get_database_stats()` error fallback (line ~485): remove `"error"` key
+
+**Test file:** `tests/test_database_disclosure.py`
+- Async tests on `DatabaseManager` directly with temp DB
+- Assert healthy response has no `database_path`
+- Assert unhealthy response has no `database_path` or `error`
+- Assert `get_database_stats()` error fallback has no `error`
+
+```text
+Write failing async tests in `tests/test_database_disclosure.py` for DatabaseManager methods.
+
+Use pytest-asyncio. Create a temporary DatabaseManager with a temp directory DB path.
+Initialize it, then test:
+1. `health_check()` healthy response does NOT contain "database_path" key
+2. `health_check()` healthy response does NOT contain "error" key
+3. `health_check()` response DOES contain "status" and "entry_count"
+4. `get_database_stats()` returns dict without "error" key (patch engine to raise to trigger error path)
+
+Run tests to confirm they fail. Then modify `web/database.py`:
+- health_check() healthy branch: remove "database_path": self.database_path
+- health_check() unhealthy branch: return {"status": "unhealthy"} only (remove "error" and "database_path")
+- get_database_stats() error fallback: remove "error": str(e) from the return dict
+Run tests to confirm they pass.
+Check existing tests in test_work_week_database.py and test_step5_sync_implementation.py for
+any assertions on "database_path" and update them if needed.
+```
+
+---
+
+## Phase 4: Fix `web/api/settings.py` (10+ endpoints with str(e))
+
+**Why:** Every except block interpolates `str(e)` into HTTPException detail.
+
+**Changes to `web/api/settings.py`:**
+- All `detail=f"Failed to ...: {str(e)}"` → `detail="Failed to ..."`
+- Settings health check unhealthy return: remove `"error": str(e)` key
+- `bulk_update` ValueError block line ~427: `'message': str(ve)` → `'message': 'Validation failed'`
+- ValueError handlers in `update_setting`, `reset_setting`, `import_settings`, `update_work_week`: `detail=str(e)` → static messages
+
+**Test file:** `tests/test_settings_disclosure.py`
+
+```text
+Write failing tests in `tests/test_settings_disclosure.py` for settings API error responses.
+
+Use `isolated_app_client` fixture. Use unittest.mock.patch to make service methods raise
+exceptions with a sentinel string "SENTINEL_LEAK_TEST". Then assert the sentinel does NOT
+appear in the HTTP response body. Test cases:
+
+1. Patch settings_service.get_all_settings to raise Exception("SENTINEL_LEAK_TEST").
+   GET /api/settings/ should return 500 with detail that does NOT contain "SENTINEL_LEAK_TEST".
+2. Patch settings_service.get_setting to raise Exception("SENTINEL_LEAK_TEST").
+   GET /api/settings/ui.theme should return 500 without the sentinel.
+3. Patch settings_service.update_setting to raise ValueError("SENTINEL_LEAK_TEST").
+   PUT /api/settings/ui.theme should return 400 without the sentinel.
+4. Patch to trigger the settings health check error path — assert no "error" key with raw string.
+5. Patch bulk_update_settings to raise ValueError("SENTINEL_LEAK_TEST").
+   POST /api/settings/bulk-update should return 400 without the sentinel.
+
+Run tests to confirm they fail. Then modify web/api/settings.py:
+- Replace all `detail=f"Failed to ...: {str(e)}"` with `detail="Failed to ..."`
+- Settings health unhealthy return: {"status": "unhealthy", "database_connected": False}
+- bulk_update ValueError: 'message': 'Validation failed' (not str(ve))
+- update_setting ValueError: detail="Invalid setting value"
+- reset_setting ValueError: detail="Cannot reset setting"
+- import_settings ValueError: detail="Invalid import data"
+- update_work_week ValueError: detail="Invalid work week configuration"
+Run tests to confirm they pass. Run existing settings tests for regressions.
+```
+
+---
+
+## Phase 5: Fix `web/api/sync.py` + `web/services/sync_service.py`
+
+**Why:** All sync endpoints leak `str(e)`. Stored `error_message` creates persistent disclosure.
+
+**Changes to `web/api/sync.py`:**
+- All 11 `detail=f"Failed to ...: {str(e)}"` → `detail="Failed to ..."`
+- `GET /api/sync/history` line ~359: `"error_message": record.error_message` → `"error_message": sanitize_error_message(record.error_message, generic="Sync failed")`
+- Add `IncrementalSyncRequest` Pydantic model for `since_days` validation (ge=1, le=365)
+
+**Changes to `web/services/sync_service.py`:**
+- `get_sync_status()` line ~536: `"error_message": sync.error_message` → `"error_message": sanitize_error_message(sync.error_message, generic="Sync failed")`
+- Lines 158, 226, 289: `_record_sync_failure(sync_id, str(e))` → `_record_sync_failure(sync_id, "Sync failed")`
+
+**Test file:** `tests/test_sync_disclosure.py`
+
+```text
+Write failing tests in `tests/test_sync_disclosure.py` for sync API error responses.
+
+Use `isolated_app_client` fixture. Test cases:
+
+1. Patch sync_service.get_sync_status to raise Exception("SENTINEL_LEAK_TEST").
+   GET /api/sync/status should return 500 without the sentinel.
+2. GET /api/sync/history — if any records have error_message, it should be "Sync failed" not raw text.
+3. POST /api/sync/incremental with {"since_days": -1} should return 422 (validation error).
+4. POST /api/sync/incremental with {"since_days": 999} should return 422.
+5. POST /api/sync/incremental with {"since_days": 7} should succeed (return 200).
+
+Run tests to confirm they fail. Then:
+1. In web/api/sync.py: strip str(e) from all HTTPException details.
+2. In web/api/sync.py: import sanitize_error_message and use it on error_message in history endpoint.
+3. In web/api/sync.py: add IncrementalSyncRequest model, refactor trigger_incremental_sync to use it.
+4. In web/services/sync_service.py: import sanitize_error_message, use in get_sync_status().
+5. In web/services/sync_service.py: change _record_sync_failure calls to pass "Sync failed" instead of str(e).
+Run tests to confirm they pass. Run existing sync tests for regressions.
+```
+
+---
+
+## Phase 6: Final Verification
+
+```text
+Run the full test suite to verify no regressions:
+  pytest -v
+
+Run a targeted grep to confirm no remaining str(e) in HTTP response details:
+  grep -rn 'detail=.*str(e)' web/api/
+  grep -rn '"error".*str(e)' web/database.py
+
+Verify the health endpoint manually if possible:
+  # Should show only status fields, no paths or provider info
+  curl http://localhost:8000/api/health/
+```
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `web/utils/error_utils.py` | NEW — sanitize_error_message utility |
+| `web/utils/__init__.py` | Add re-export |
+| `web/api/health.py` | Strip sensitive fields from public endpoint |
+| `web/api/settings.py` | Remove str(e) from all HTTPException details |
+| `web/api/sync.py` | Remove str(e), add input validation model, sanitize error_message |
+| `web/database.py` | Remove database_path and str(e) from health/stats responses |
+| `web/services/sync_service.py` | Sanitize error_message on read + write |
+| `tests/test_error_utils.py` | NEW |
+| `tests/test_health_disclosure.py` | NEW |
+| `tests/test_database_disclosure.py` | NEW |
+| `tests/test_settings_disclosure.py` | NEW |
+| `tests/test_sync_disclosure.py` | NEW |

--- a/tests/test_database_disclosure.py
+++ b/tests/test_database_disclosure.py
@@ -1,0 +1,69 @@
+# ABOUTME: Security tests for DatabaseManager response sanitization.
+# ABOUTME: Verifies health_check and get_database_stats do not leak internal paths or errors.
+"""Tests that DatabaseManager methods do not disclose internal details."""
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, patch
+from web.database import DatabaseManager
+
+
+@pytest_asyncio.fixture
+async def db_manager(tmp_path):
+    """Create an isolated DatabaseManager for testing."""
+    db_path = str(tmp_path / "test.db")
+    manager = DatabaseManager(database_path=db_path)
+    await manager.initialize()
+    return manager
+
+
+class TestHealthCheckDisclosure:
+    """health_check() must not expose database_path or raw error strings."""
+
+    @pytest.mark.asyncio
+    async def test_healthy_no_database_path(self, db_manager):
+        result = await db_manager.health_check()
+        assert result["status"] == "healthy"
+        assert "database_path" not in result
+
+    @pytest.mark.asyncio
+    async def test_healthy_no_error_key(self, db_manager):
+        result = await db_manager.health_check()
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_healthy_has_entry_count(self, db_manager):
+        result = await db_manager.health_check()
+        assert "entry_count" in result
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_no_database_path(self, db_manager):
+        """When the DB is broken, the response must still not leak the path."""
+        # Dispose the engine to force a failure
+        await db_manager.engine.dispose()
+        db_manager.SessionLocal = None
+        # Force an exception by making get_session fail
+        with patch.object(db_manager, 'get_session', side_effect=Exception("connection failed")):
+            result = await db_manager.health_check()
+            assert result["status"] == "unhealthy"
+            assert "database_path" not in result
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_no_error_string(self, db_manager):
+        """When the DB is broken, the raw error string must not be returned."""
+        with patch.object(db_manager, 'get_session', side_effect=Exception("secret path /var/db")):
+            result = await db_manager.health_check()
+            assert "error" not in result
+
+
+class TestGetDatabaseStatsDisclosure:
+    """get_database_stats() must not expose raw error strings on failure."""
+
+    @pytest.mark.asyncio
+    async def test_stats_error_no_error_key(self, db_manager):
+        """When stats collection fails, no 'error' key should be in the response."""
+        with patch.object(db_manager, 'get_session', side_effect=Exception("internal error details")):
+            result = await db_manager.get_database_stats()
+            assert "error" not in result
+            # Should still return zeroed-out stats
+            assert result["total_entries"] == 0

--- a/tests/test_error_utils.py
+++ b/tests/test_error_utils.py
@@ -1,0 +1,29 @@
+# ABOUTME: Tests for the error message sanitization utility.
+# ABOUTME: Validates that raw exception strings are never passed through to callers.
+"""Tests for web.utils.error_utils."""
+
+from web.utils.error_utils import sanitize_error_message
+
+
+class TestSanitizeErrorMessage:
+    """Tests for sanitize_error_message()."""
+
+    def test_none_returns_none(self):
+        """None input means no error occurred — should pass through as None."""
+        assert sanitize_error_message(None) is None
+
+    def test_non_none_returns_generic(self):
+        """Any real error string should be replaced with the generic message."""
+        result = sanitize_error_message("FATAL: unable to open /var/db/journal.db")
+        assert result == "An error occurred"
+        assert "/var/db" not in result
+
+    def test_custom_generic(self):
+        """Caller can specify a domain-specific generic message."""
+        result = sanitize_error_message("connection refused", generic="Sync failed")
+        assert result == "Sync failed"
+
+    def test_empty_string_returns_generic(self):
+        """Empty string is still a non-None value — sanitize it."""
+        result = sanitize_error_message("")
+        assert result == "An error occurred"

--- a/tests/test_health_disclosure.py
+++ b/tests/test_health_disclosure.py
@@ -1,0 +1,46 @@
+# ABOUTME: Security tests for the public health endpoint.
+# ABOUTME: Verifies no filesystem paths, DB paths, or provider details leak in responses.
+"""Tests that GET /api/health/ does not disclose internal details."""
+
+import json
+import pytest
+
+
+class TestHealthPublicEndpointDisclosure:
+    """The public health endpoint must not expose internal infrastructure details."""
+
+    def test_no_base_path_in_response(self, isolated_app_client):
+        """Filesystem base_path must not appear anywhere in the health response."""
+        response = isolated_app_client.get("/api/health/")
+        body = json.dumps(response.json())
+        assert "base_path" not in body
+
+    def test_no_database_path_in_response(self, isolated_app_client):
+        """Database path must not appear anywhere in the health response."""
+        response = isolated_app_client.get("/api/health/")
+        body = json.dumps(response.json())
+        assert "database_path" not in body
+
+    def test_no_llm_provider_in_response(self, isolated_app_client):
+        """LLM provider name must not appear in the health response."""
+        response = isolated_app_client.get("/api/health/")
+        body = json.dumps(response.json())
+        assert "llm_provider" not in body
+
+    def test_required_fields_present(self, isolated_app_client):
+        """The health response must still contain its contractual top-level fields."""
+        response = isolated_app_client.get("/api/health/")
+        assert response.status_code == 200
+        data = response.json()
+        for field in ["status", "service", "version", "timestamp"]:
+            assert field in data, f"Missing required field: {field}"
+
+    def test_components_contain_only_status(self, isolated_app_client):
+        """Each component in the health response should expose only a status field."""
+        response = isolated_app_client.get("/api/health/")
+        data = response.json()
+        components = data.get("components", {})
+        for name, component in components.items():
+            assert list(component.keys()) == ["status"], (
+                f"Component '{name}' exposes keys beyond 'status': {list(component.keys())}"
+            )

--- a/tests/test_settings_disclosure.py
+++ b/tests/test_settings_disclosure.py
@@ -1,0 +1,120 @@
+# ABOUTME: Security tests for settings API error response sanitization.
+# ABOUTME: Verifies raw exception strings never leak through HTTPException details.
+"""Tests that settings API endpoints do not disclose internal error details."""
+
+import json
+import pytest
+from unittest.mock import patch, AsyncMock
+
+from web.app import app
+
+
+SENTINEL = "SENTINEL_LEAK_TEST_xyz789"
+
+
+class TestSettingsErrorDisclosure:
+    """Settings endpoints must not expose raw exception strings in responses."""
+
+    def test_get_all_settings_500_no_leak(self, isolated_app_client):
+        """GET /api/settings/ must not leak exception details on 500."""
+        with patch.object(
+            app.state.settings_service, 'get_all_settings',
+            new_callable=AsyncMock, side_effect=Exception(SENTINEL)
+        ):
+            response = isolated_app_client.get("/api/settings/")
+            assert response.status_code == 500
+            assert SENTINEL not in json.dumps(response.json())
+
+    def test_get_setting_500_no_leak(self, isolated_app_client):
+        """GET /api/settings/{key} must not leak exception details on 500."""
+        with patch.object(
+            app.state.settings_service, 'get_setting',
+            new_callable=AsyncMock, side_effect=Exception(SENTINEL)
+        ):
+            response = isolated_app_client.get("/api/settings/ui.theme")
+            assert response.status_code == 500
+            assert SENTINEL not in json.dumps(response.json())
+
+    def test_update_setting_valueerror_no_leak(self, isolated_app_client):
+        """PUT /api/settings/{key} must not leak ValueError details on 400."""
+        with patch.object(
+            app.state.settings_service, 'update_setting',
+            new_callable=AsyncMock, side_effect=ValueError(SENTINEL)
+        ):
+            response = isolated_app_client.put(
+                "/api/settings/ui.theme",
+                json={"value": "dark"}
+            )
+            assert response.status_code == 400
+            assert SENTINEL not in json.dumps(response.json())
+
+    def test_settings_health_unhealthy_no_error_key(self, isolated_app_client):
+        """GET /api/settings/health unhealthy path must not include 'error' key."""
+        with patch.object(
+            app.state.settings_service, 'get_setting',
+            new_callable=AsyncMock, side_effect=Exception(SENTINEL)
+        ):
+            response = isolated_app_client.get("/api/settings/health")
+            data = response.json()
+            assert "error" not in data
+            if data.get("status") == "unhealthy":
+                assert SENTINEL not in json.dumps(data)
+
+    def test_bulk_update_valueerror_no_leak(self, isolated_app_client):
+        """POST /api/settings/bulk-update must not leak ValueError details."""
+        with patch.object(
+            app.state.settings_service, 'bulk_update_settings',
+            new_callable=AsyncMock, side_effect=ValueError(SENTINEL)
+        ):
+            response = isolated_app_client.post(
+                "/api/settings/bulk-update",
+                json={"settings": {"ui.theme": "dark"}}
+            )
+            assert response.status_code == 400
+            assert SENTINEL not in json.dumps(response.json())
+
+    def test_reset_setting_valueerror_no_leak(self, isolated_app_client):
+        """POST /api/settings/{key}/reset must not leak ValueError details."""
+        with patch.object(
+            app.state.settings_service, 'reset_setting',
+            new_callable=AsyncMock, side_effect=ValueError(SENTINEL)
+        ):
+            response = isolated_app_client.post("/api/settings/ui.theme/reset")
+            assert response.status_code == 400
+            assert SENTINEL not in json.dumps(response.json())
+
+    def test_import_settings_valueerror_no_leak(self, isolated_app_client):
+        """POST /api/settings/import must not leak ValueError details."""
+        with patch.object(
+            app.state.settings_service, 'import_settings',
+            new_callable=AsyncMock, side_effect=ValueError(SENTINEL)
+        ):
+            response = isolated_app_client.post(
+                "/api/settings/import",
+                json={"settings": {"ui.theme": "dark"}}
+            )
+            assert response.status_code == 400
+            assert SENTINEL not in json.dumps(response.json())
+
+    def test_work_week_500_no_leak(self, isolated_app_client):
+        """GET /api/settings/work-week must not leak exception details."""
+        with patch.object(
+            app.state.settings_service, 'get_work_week_settings',
+            new_callable=AsyncMock, side_effect=Exception(SENTINEL)
+        ):
+            response = isolated_app_client.get("/api/settings/work-week")
+            assert response.status_code == 500
+            assert SENTINEL not in json.dumps(response.json())
+
+    def test_update_work_week_valueerror_no_leak(self, isolated_app_client):
+        """POST /api/settings/work-week must not leak ValueError details."""
+        with patch.object(
+            app.state.settings_service, 'update_work_week_configuration',
+            new_callable=AsyncMock, side_effect=ValueError(SENTINEL)
+        ):
+            response = isolated_app_client.post(
+                "/api/settings/work-week",
+                json={"preset": "custom", "start_day": 1, "end_day": 5}
+            )
+            assert response.status_code == 400
+            assert SENTINEL not in json.dumps(response.json())

--- a/tests/test_sync_disclosure.py
+++ b/tests/test_sync_disclosure.py
@@ -1,0 +1,116 @@
+# ABOUTME: Security tests for sync API error response sanitization.
+# ABOUTME: Verifies raw exception strings and stored error messages don't leak.
+"""Tests that sync API endpoints do not disclose internal error details."""
+
+import json
+import pytest
+from unittest.mock import patch, AsyncMock
+
+from web.app import app
+
+
+SENTINEL = "SENTINEL_SYNC_LEAK_xyz789"
+
+
+class TestSyncErrorDisclosure:
+    """Sync endpoints must not expose raw exception strings in responses."""
+
+    def test_get_sync_status_500_no_leak(self, isolated_app_client):
+        """GET /api/sync/status must not leak exception details on 500."""
+        with patch.object(
+            app.state.sync_service, 'get_sync_status',
+            new_callable=AsyncMock, side_effect=Exception(SENTINEL)
+        ):
+            response = isolated_app_client.get("/api/sync/status")
+            assert response.status_code == 500
+            assert SENTINEL not in json.dumps(response.json())
+
+    def test_get_scheduler_status_500_no_leak(self, isolated_app_client):
+        """GET /api/sync/scheduler/status must not leak exception details."""
+        if hasattr(app.state, 'scheduler') and app.state.scheduler:
+            with patch.object(
+                app.state.scheduler, 'get_scheduler_status',
+                side_effect=Exception(SENTINEL)
+            ):
+                response = isolated_app_client.get("/api/sync/scheduler/status")
+                if response.status_code == 500:
+                    assert SENTINEL not in json.dumps(response.json())
+
+    def test_full_sync_500_no_leak(self, isolated_app_client):
+        """POST /api/sync/full must not leak exception details on 500."""
+        with patch.object(
+            app.state.sync_service, 'get_sync_status',
+            new_callable=AsyncMock, side_effect=Exception(SENTINEL)
+        ):
+            response = isolated_app_client.post("/api/sync/full")
+            assert response.status_code == 500
+            assert SENTINEL not in json.dumps(response.json())
+
+    def test_sync_history_500_no_leak(self, isolated_app_client):
+        """GET /api/sync/history must not leak exception details on 500."""
+        with patch.object(
+            app.state.sync_service.db_manager, 'get_session',
+            side_effect=Exception(SENTINEL)
+        ):
+            response = isolated_app_client.get("/api/sync/history")
+            assert response.status_code == 500
+            assert SENTINEL not in json.dumps(response.json())
+
+
+class TestSyncHistoryErrorMessageSanitization:
+    """Stored error_message values must be sanitized before returning to clients."""
+
+    def test_sync_status_error_message_sanitized(self, isolated_app_client):
+        """GET /api/sync/status should not return raw error_message strings."""
+        response = isolated_app_client.get("/api/sync/status")
+        if response.status_code == 200:
+            data = response.json()
+            for sync in data.get("sync_status", {}).get("recent_syncs", []):
+                if sync.get("error_message") is not None:
+                    # Should be a generic message, not a raw exception
+                    assert sync["error_message"] == "Sync failed"
+
+
+class TestIncrementalSyncInputValidation:
+    """POST /api/sync/incremental must validate since_days bounds."""
+
+    def test_negative_since_days_rejected(self, isolated_app_client):
+        """Negative since_days must be rejected."""
+        response = isolated_app_client.post(
+            "/api/sync/incremental",
+            json={"since_days": -1}
+        )
+        assert response.status_code == 422
+
+    def test_zero_since_days_rejected(self, isolated_app_client):
+        """Zero since_days must be rejected."""
+        response = isolated_app_client.post(
+            "/api/sync/incremental",
+            json={"since_days": 0}
+        )
+        assert response.status_code == 422
+
+    def test_excessive_since_days_rejected(self, isolated_app_client):
+        """since_days > 365 must be rejected."""
+        response = isolated_app_client.post(
+            "/api/sync/incremental",
+            json={"since_days": 999}
+        )
+        assert response.status_code == 422
+
+    def test_valid_since_days_accepted(self, isolated_app_client):
+        """Valid since_days should be accepted (returns 200 even if sync can't run)."""
+        response = isolated_app_client.post(
+            "/api/sync/incremental",
+            json={"since_days": 7}
+        )
+        # 200 or 409 (already in progress) are both acceptable
+        assert response.status_code in (200, 409)
+
+    def test_non_integer_since_days_rejected(self, isolated_app_client):
+        """Non-integer since_days must be rejected."""
+        response = isolated_app_client.post(
+            "/api/sync/incremental",
+            json={"since_days": "abc"}
+        )
+        assert response.status_code == 422

--- a/todo.md
+++ b/todo.md
@@ -33,6 +33,12 @@ Full design: [docs/superpowers/specs/2026-05-08-issue-triage-design.md](docs/sup
 - [ ] [#94](https://github.com/lbnl-science-it/WorkJournalMaker/issues/94) — Prompt injection via unsanitized journal content
 - [ ] [#95](https://github.com/lbnl-science-it/WorkJournalMaker/issues/95) — Unrestricted base_path enables arbitrary file write
 - [ ] [#96](https://github.com/lbnl-science-it/WorkJournalMaker/issues/96) — Information disclosure via error messages
+  - [ ] Phase 1: Create `web/utils/error_utils.py` + tests
+  - [ ] Phase 2: Fix `web/api/health.py` public endpoint info leak + tests
+  - [ ] Phase 3: Fix `web/database.py` health_check/get_database_stats + tests
+  - [ ] Phase 4: Fix `web/api/settings.py` str(e) in 10+ endpoints + tests
+  - [ ] Phase 5: Fix `web/api/sync.py` + `web/services/sync_service.py` + tests
+  - [ ] Phase 6: Full regression verification
 - [ ] [#97](https://github.com/lbnl-science-it/WorkJournalMaker/issues/97) — CORS misconfiguration
 - [ ] [#98](https://github.com/lbnl-science-it/WorkJournalMaker/issues/98) — GCP project ID hardcoded in source code
 - [ ] [#99](https://github.com/lbnl-science-it/WorkJournalMaker/issues/99) — Client-only input validation

--- a/web/api/health.py
+++ b/web/api/health.py
@@ -43,15 +43,12 @@ async def health_check(request: Request):
         version="1.0.0",
         timestamp=datetime.utcnow(),
         components={
-            "database": db_health,
+            "database": {"status": db_health["status"]},
             "filesystem": {
-                "status": "healthy" if fs_accessible else "unhealthy",
-                "base_path": str(base_path),
-                "accessible": fs_accessible
+                "status": "healthy" if fs_accessible else "unhealthy"
             },
             "configuration": {
-                "status": "healthy" if config else "unhealthy",
-                "llm_provider": config.llm.provider if config else None
+                "status": "healthy" if config else "unhealthy"
             }
         }
     )

--- a/web/api/settings.py
+++ b/web/api/settings.py
@@ -44,7 +44,7 @@ async def get_all_settings(
         settings_service.logger.logger.error(f"Failed to get all settings: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to retrieve settings: {str(e)}"
+            detail="Failed to retrieve settings"
         )
 
 @router.get("/categories", response_model=SettingsCategoryResponse)
@@ -60,7 +60,7 @@ async def get_settings_categories(
         settings_service.logger.logger.error(f"Failed to get settings categories: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to retrieve categories: {str(e)}"
+            detail="Failed to retrieve categories"
         )
 
 @router.get("/health")
@@ -83,7 +83,6 @@ async def settings_health_check(
         settings_service.logger.logger.error(f"Settings health check failed: {str(e)}")
         return {
             "status": "unhealthy",
-            "error": str(e),
             "database_connected": False
         }
 
@@ -142,7 +141,7 @@ async def get_work_week_configuration(
         settings_service.logger.logger.error(f"Failed to get work week configuration: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to retrieve work week configuration: {str(e)}"
+            detail="Failed to retrieve work week configuration"
         )
 
 @router.post("/work-week", response_model=WorkWeekUpdateResponse)
@@ -175,13 +174,13 @@ async def update_work_week_configuration(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e)
+            detail="Invalid work week configuration"
         )
     except Exception as e:
         settings_service.logger.logger.error(f"Failed to update work week configuration: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to update work week configuration: {str(e)}"
+            detail="Failed to update work week configuration"
         )
 
 @router.get("/work-week/presets", response_model=WorkWeekPresetsResponse)
@@ -215,7 +214,7 @@ async def get_work_week_presets(
         settings_service.logger.logger.error(f"Failed to get work week presets: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to retrieve work week presets: {str(e)}"
+            detail="Failed to retrieve work week presets"
         )
 
 @router.post("/work-week/validate", response_model=WorkWeekValidationResponse)
@@ -275,7 +274,7 @@ async def validate_work_week_configuration(
         settings_service.logger.logger.error(f"Failed to validate work week configuration: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to validate work week configuration: {str(e)}"
+            detail="Failed to validate work week configuration"
         )
 
 @router.get("/{key}", response_model=WebSettingResponse)
@@ -299,7 +298,7 @@ async def get_setting(
         settings_service.logger.logger.error(f"Failed to get setting {key}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to retrieve setting: {str(e)}"
+            detail="Failed to retrieve setting"
         )
 
 @router.put("/{key}", response_model=WebSettingResponse)
@@ -321,13 +320,13 @@ async def update_setting(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e)
+            detail="Invalid setting value"
         )
     except Exception as e:
         settings_service.logger.logger.error(f"Failed to update setting {key}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to update setting: {str(e)}"
+            detail="Failed to update setting"
         )
 
 @router.post("/bulk-update", response_model=SettingsBulkUpdateResponse)
@@ -424,7 +423,7 @@ async def bulk_update_settings(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 'error': 'Validation failed',
-                'message': str(ve),
+                'message': 'Validation failed',
                 'request_id': request_id,
                 'timestamp': datetime.now().isoformat()
             }
@@ -510,13 +509,13 @@ async def reset_setting(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e)
+            detail="Cannot reset setting"
         )
     except Exception as e:
         settings_service.logger.logger.error(f"Failed to reset setting {key}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to reset setting: {str(e)}"
+            detail="Failed to reset setting"
         )
 
 @router.post("/reset-all", response_model=Dict[str, WebSettingResponse])
@@ -532,7 +531,7 @@ async def reset_all_settings(
         settings_service.logger.logger.error(f"Failed to reset all settings: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to reset all settings: {str(e)}"
+            detail="Failed to reset all settings"
         )
 
 @router.get("/export/current", response_model=SettingsExport)
@@ -548,7 +547,7 @@ async def export_settings(
         settings_service.logger.logger.error(f"Failed to export settings: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to export settings: {str(e)}"
+            detail="Failed to export settings"
         )
 
 @router.post("/import", response_model=Dict[str, WebSettingResponse])
@@ -564,13 +563,13 @@ async def import_settings(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e)
+            detail="Invalid import data"
         )
     except Exception as e:
         settings_service.logger.logger.error(f"Failed to import settings: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to import settings: {str(e)}"
+            detail="Failed to import settings"
         )
 
 def _is_path_within_allowed_roots(resolved_path: Path, allowed_roots: list) -> bool:

--- a/web/api/sync.py
+++ b/web/api/sync.py
@@ -7,8 +7,9 @@ This module provides REST API endpoints for managing and monitoring
 database synchronization operations.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, BackgroundTasks, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
 from datetime import date, datetime, timedelta
 from typing import Optional, Dict, Any
 from config_manager import AppConfig
@@ -17,6 +18,12 @@ from web.auth import get_current_user, require_admin, User
 from web.database import DatabaseManager
 from web.services.sync_service import DatabaseSyncService, SyncType
 from web.services.scheduler import SyncScheduler
+from web.utils.error_utils import sanitize_error_message
+
+
+class IncrementalSyncRequest(BaseModel):
+    """Request body for incremental sync with validated bounds."""
+    since_days: int = Field(default=7, ge=1, le=365)
 
 router = APIRouter(prefix="/api/sync", tags=["synchronization"])
 
@@ -52,7 +59,7 @@ async def get_sync_status(
             "timestamp": datetime.utcnow().isoformat()
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get sync status: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to get sync status")
 
 
 @router.get("/scheduler/status")
@@ -72,7 +79,7 @@ async def get_scheduler_status(
     try:
         return scheduler.get_scheduler_status()
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get scheduler status: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to get scheduler status")
 
 
 @router.post("/full")
@@ -109,38 +116,36 @@ async def trigger_full_sync(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to start full sync: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to start full sync")
 
 
 @router.post("/incremental")
 async def trigger_incremental_sync(
-    request: Request,
     background_tasks: BackgroundTasks,
+    body: IncrementalSyncRequest = Body(default_factory=IncrementalSyncRequest),
     sync_service: DatabaseSyncService = Depends(get_sync_service),
     user: User = Depends(require_admin)
 ):
     """
     Trigger an incremental synchronization for recent changes.
-    
+
     Args:
-        request: FastAPI request object
-        
+        body: Request body with since_days (1-365, default 7)
+
     Returns:
         Dict with sync operation details
     """
     try:
-        # Parse request body
-        body = await request.json() if request.headers.get("content-type") == "application/json" else {}
-        since_days = body.get("since_days", 7)
-        
+        since_days = body.since_days
+
         # Log for debugging
         sync_service.logger.logger.info(f"API triggered incremental sync with since_days: {since_days}")
-        
+
         since_date = date.today() - timedelta(days=since_days)
-        
+
         # Start sync in background
         background_tasks.add_task(_run_incremental_sync, sync_service, since_date)
-        
+
         return {
             "message": "Incremental sync started",
             "sync_type": "incremental",
@@ -149,7 +154,7 @@ async def trigger_incremental_sync(
             "started_at": datetime.utcnow().isoformat()
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to start incremental sync: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to start incremental sync")
 
 
 @router.post("/entry/{entry_date}")
@@ -179,7 +184,7 @@ async def sync_single_entry(
             "started_at": datetime.utcnow().isoformat()
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to start entry sync: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to start entry sync")
 
 
 @router.post("/scheduler/start")
@@ -203,7 +208,7 @@ async def start_scheduler(
             "started_at": datetime.utcnow().isoformat()
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to start scheduler: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to start scheduler")
 
 
 @router.post("/scheduler/stop")
@@ -227,7 +232,7 @@ async def stop_scheduler(
             "stopped_at": datetime.utcnow().isoformat()
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to stop scheduler: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to stop scheduler")
 
 
 @router.post("/scheduler/trigger/incremental")
@@ -252,7 +257,7 @@ async def trigger_scheduler_incremental(
             "triggered_at": datetime.utcnow().isoformat()
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to trigger incremental sync: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to trigger incremental sync")
 
 
 @router.post("/scheduler/trigger/full")
@@ -277,7 +282,7 @@ async def trigger_scheduler_full(
             "triggered_at": datetime.utcnow().isoformat()
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to trigger full sync: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to trigger full sync")
 
 
 @router.put("/scheduler/config")
@@ -311,7 +316,7 @@ async def update_scheduler_config(
             }
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to update scheduler config: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to update scheduler config")
 
 
 @router.get("/history")
@@ -356,7 +361,7 @@ async def get_sync_history(
                         "entries_added": record.entries_added,
                         "entries_updated": record.entries_updated,
                         "entries_removed": record.entries_removed,
-                        "error_message": record.error_message,
+                        "error_message": sanitize_error_message(record.error_message, generic="Sync failed"),
                         "duration_seconds": (
                             (record.completed_at - record.started_at).total_seconds()
                             if record.completed_at else None
@@ -368,7 +373,7 @@ async def get_sync_history(
                 "retrieved_at": datetime.utcnow().isoformat()
             }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get sync history: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to get sync history")
 
 
 # Background task functions

--- a/web/database.py
+++ b/web/database.py
@@ -481,8 +481,7 @@ class DatabaseManager:
                 "entries_with_content": 0,
                 "date_range": None,
                 "last_sync": None,
-                "database_size_mb": 0.0,
-                "error": str(e)
+                "database_size_mb": 0.0
             }
     
     @asynccontextmanager
@@ -513,15 +512,12 @@ class DatabaseManager:
                 
                 return {
                     "status": "healthy",
-                    "database_path": self.database_path,
                     "entry_count": entry_count,
                     "connection": "active"
                 }
         except Exception as e:
             return {
-                "status": "unhealthy",
-                "error": str(e),
-                "database_path": self.database_path
+                "status": "unhealthy"
             }
     
     # Work Week Settings Methods

--- a/web/services/sync_service.py
+++ b/web/services/sync_service.py
@@ -21,6 +21,7 @@ from file_discovery import FileDiscovery, FileDiscoveryResult
 from config_manager import AppConfig
 from logger import JournalSummarizerLogger, ErrorCategory
 from web.database import DatabaseManager, JournalEntryIndex, SyncStatus
+from web.utils.error_utils import sanitize_error_message
 from sqlalchemy import select, update, delete, and_, or_, func
 from sqlalchemy.exc import IntegrityError
 
@@ -155,7 +156,7 @@ class DatabaseSyncService:
         except Exception as e:
             sync_result.errors.append(str(e))
             self.logger.log_error_with_category(ErrorCategory.DATABASE_ERROR, f"Full sync failed: {str(e)}")
-            await self._record_sync_failure(sync_id, str(e))
+            await self._record_sync_failure(sync_id, "Sync failed")
             
         finally:
             self._sync_in_progress = False
@@ -223,7 +224,7 @@ class DatabaseSyncService:
         except Exception as e:
             sync_result.errors.append(str(e))
             self.logger.log_error_with_category(ErrorCategory.DATABASE_ERROR, f"Incremental sync failed: {str(e)}")
-            await self._record_sync_failure(sync_id, str(e))
+            await self._record_sync_failure(sync_id, "Sync failed")
             
         finally:
             self._sync_in_progress = False
@@ -286,7 +287,7 @@ class DatabaseSyncService:
         except Exception as e:
             sync_result.errors.append(str(e))
             self.logger.log_error_with_category(ErrorCategory.DATABASE_ERROR, f"Single entry sync failed for {entry_date}: {str(e)}")
-            await self._record_sync_failure(sync_id, str(e))
+            await self._record_sync_failure(sync_id, "Sync failed")
             
         finally:
             self._sync_in_progress = False
@@ -533,7 +534,7 @@ class DatabaseSyncService:
                         "entries_added": sync.entries_added,
                         "entries_updated": sync.entries_updated,
                         "entries_removed": sync.entries_removed,
-                        "error_message": sync.error_message
+                        "error_message": sanitize_error_message(sync.error_message, generic="Sync failed")
                     }
                     for sync in recent_syncs
                 ]

--- a/web/utils/__init__.py
+++ b/web/utils/__init__.py
@@ -4,6 +4,7 @@
 Web utilities package for timezone handling and other common functions.
 """
 
+from .error_utils import sanitize_error_message
 from .timezone_utils import (
     TimezoneManager,
     get_timezone_manager,
@@ -16,6 +17,7 @@ from .timezone_utils import (
 )
 
 __all__ = [
+    'sanitize_error_message',
     'TimezoneManager',
     'get_timezone_manager',
     'now_local',

--- a/web/utils/error_utils.py
+++ b/web/utils/error_utils.py
@@ -1,0 +1,17 @@
+# ABOUTME: Utilities for safe error responses that avoid leaking internal details.
+# ABOUTME: Provides a sanitize function for stored error strings before HTTP serialization.
+"""Error sanitization utilities for API responses."""
+
+from typing import Optional
+
+
+def sanitize_error_message(raw: Optional[str], *, generic: str = "An error occurred") -> Optional[str]:
+    """Replace a raw error string with a generic message safe for API responses.
+
+    Returns None when raw is None (no error occurred), otherwise returns the
+    generic message regardless of raw content, preventing internal details
+    from leaking to clients.
+    """
+    if raw is None:
+        return None
+    return generic


### PR DESCRIPTION
  ## Summary

  - Sanitize error messages across all web API endpoints to prevent leaking internal paths, database locations, and Python
  exception details to clients (OWASP A05:2021)
  - Strip sensitive configuration fields (`base_path`, `database_path`, `llm_provider`) from the public `/api/health/`
  endpoint while preserving admin-gated `/config` and `/metrics`
  - Add `since_days` input validation via Pydantic model on incremental sync endpoints

  ## Changes by phase

  | Phase | Scope | Commit |
  | ----- | ----- | ------ |
  | 1 | `web/utils/error_utils.py` — `sanitize_error_message()` utility + 4 tests | `5bfc277` |
  | 2 | `web/api/health.py` — strip sensitive fields from public health response + 5 tests | `a5fce62` |
  | 3 | `web/database.py` — remove `database_path` and `str(e)` from DB responses + 6 tests | `d6359f5` |
  | 4 | `web/api/settings.py` — replace `str(e)` in 10+ HTTPException details + 9 tests | `7bc0f68` |
  | 5 | `web/api/sync.py`, `web/services/sync_service.py` — sanitize all 11 sync endpoints + `since_days` validation + 10
  tests | `71b25d4` |
  | 6 | Full regression — 34 new tests pass, no regressions introduced | (verification only) |

  ## Design decisions

  - Used inline generic strings for `HTTPException.detail` (matching existing safe pattern in `web/api/entries.py`)
  - Single utility function (`sanitize_error_message`) only for the stored `error_message` DB column, which is read in
  multiple places
  - Sync `error_message` sanitized on both read AND write (defense in depth)
  - 4 remaining `str(e)` usages in `entries.py`, `calendar.py`, `summarization.py` are out of scope — separate issue

  ## Test plan

  - [x] All 34 new disclosure tests pass
  - [x] Full suite: no regressions from these changes (1507 passed; 140 failures + 8 errors are pre-existing)
  - [ ] Manual: confirm `/api/health/` no longer returns `base_path`, `database_path`, or `llm_provider`
  - [ ] Manual: trigger a settings save error and confirm the response contains a generic message, not a traceback

  Closes #96