### PR TITLE
fix(security): replace hardcoded GCP project ID with placeholder (#98)

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -80,7 +80,7 @@ class BedrockConfig:
 @dataclass
 class GoogleGenAIConfig:
     """Configuration for Google GenAI API integration."""
-    project: str = "geminijournal-463220"
+    project: str = "your-gcp-project-id"
     location: str = "us-central1"
     model: str = "gemini-2.0-flash-001"
 
@@ -529,7 +529,7 @@ class ConfigManager:
                 'rate_limit_delay': 1.0
             },
             'google_genai': {
-                'project': 'geminijournal-463220',
+                'project': 'your-gcp-project-id',
                 'location': 'us-central1',
                 'model': 'gemini-2.0-flash-001'
             },

--- a/scripts/test-executable.sh
+++ b/scripts/test-executable.sh
@@ -19,7 +19,7 @@ llm:
   provider: google_genai
 
 google_genai:
-  project: geminijournal-463220
+  project: your-gcp-project-id
   location: us-central1
   model: gemini-2.0-flash-001
 

--- a/tests/geminitest.py
+++ b/tests/geminitest.py
@@ -1,7 +1,7 @@
 from google import genai
 
 client = genai.Client(vertexai=True,
-                      project="geminijournal-463220",
+                      project="your-gcp-project-id",
                       location="us-central1")
 
 response = client.models.generate_content(

--- a/tests/test_gcp_project_id.py
+++ b/tests/test_gcp_project_id.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# ABOUTME: Tests that no real GCP project ID is hardcoded in config defaults.
+# ABOUTME: Ensures GoogleGenAIConfig ships with a placeholder, not production infrastructure metadata.
+"""
+Tests for GH#98 — GCP project ID must not be hardcoded in source code.
+"""
+
+import pytest
+
+from config_manager import GoogleGenAIConfig
+
+
+class TestGCPProjectIDNotHardcoded:
+    """Verify the default GoogleGenAIConfig does not contain real infrastructure IDs."""
+
+    def test_default_project_is_placeholder(self):
+        """Default project must not be the real GCP project ID."""
+        config = GoogleGenAIConfig()
+        assert config.project != "geminijournal-463220", (
+            "Real GCP project ID is hardcoded as default"
+        )
+
+    def test_default_project_signals_user_action_needed(self):
+        """Default project value must clearly indicate it needs to be configured."""
+        config = GoogleGenAIConfig()
+        # Should be an obvious placeholder, not something that looks like a real ID
+        assert "your" in config.project.lower() or "change" in config.project.lower() or "set" in config.project.lower(), (
+            "Default project should be an obvious placeholder prompting user configuration"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_google_genai_client.py
+++ b/tests/test_google_genai_client.py
@@ -651,7 +651,7 @@ class TestGoogleGenAIClient:
         """Test default configuration values."""
         config = GoogleGenAIConfig()
         
-        assert config.project == "geminijournal-463220"
+        assert config.project == "your-gcp-project-id"
         assert config.location == "us-central1"
         assert config.model == "gemini-2.0-flash-001"
     

--- a/tests/test_main_application_integration.py
+++ b/tests/test_main_application_integration.py
@@ -83,7 +83,7 @@ def google_genai_config():
     return AppConfig(
         bedrock=BedrockConfig(),  # Still needed for backward compatibility
         google_genai=GoogleGenAIConfig(
-            project="geminijournal-463220",
+            project="test-gcp-project",
             location="us-central1",
             model="gemini-2.0-flash-001"
         ),
@@ -330,7 +330,7 @@ class TestMainApplicationIntegration:
         mock_client_instance.test_connection.return_value = True
         mock_client_instance.get_provider_name.return_value = "google_genai"
         mock_client_instance.get_provider_info.return_value = {
-            "project": "geminijournal-463220",
+            "project": "test-gcp-project",
             "location": "us-central1",
             "model": "gemini-2.0-flash-001"
         }
@@ -353,7 +353,7 @@ class TestMainApplicationIntegration:
         # Verify output contains provider information
         captured = capsys.readouterr()
         assert "google_genai" in captured.out.lower()
-        assert "geminijournal-463220" in captured.out
+        assert "test-gcp-project" in captured.out
 
     @patch('work_journal_summarizer.ConfigManager')
     @patch('work_journal_summarizer.UnifiedLLMClient')

--- a/todo.md
+++ b/todo.md
@@ -40,7 +40,7 @@ Full design: [docs/superpowers/specs/2026-05-08-issue-triage-design.md](docs/sup
   - [x] Phase 5: Fix `web/api/sync.py` + `web/services/sync_service.py` + tests
   - [x] Phase 6: Full regression verification
 - [x] [#97](https://github.com/lbnl-science-it/WorkJournalMaker/issues/97) — CORS misconfiguration
-- [ ] [#98](https://github.com/lbnl-science-it/WorkJournalMaker/issues/98) — GCP project ID hardcoded in source code
+- [x] [#98](https://github.com/lbnl-science-it/WorkJournalMaker/issues/98) — GCP project ID hardcoded in source code
 - [ ] [#99](https://github.com/lbnl-science-it/WorkJournalMaker/issues/99) — Client-only input validation
 - [ ] [#110](https://github.com/lbnl-science-it/WorkJournalMaker/issues/110) — Bulk update settings always returns HTTP 200
 


### PR DESCRIPTION
## Summary

  - Replace hardcoded GCP project ID `geminijournal-463220` with placeholder `your-gcp-project-id` in config defaults, example config, tests, and scripts
  - Add guard tests to prevent real project IDs from being reintroduced

  ## Changes

  | File | Change |
  | ---- | ------ |
  | `config_manager.py` | Default + example config → placeholder |
  | `tests/geminitest.py` | → placeholder |
  | `tests/test_main_application_integration.py` | → test placeholder |
  | `tests/test_google_genai_client.py` | Updated default assertion |
  | `scripts/test-executable.sh` | → placeholder |
  | `tests/test_gcp_project_id.py` | 2 new guard tests |

  ## Test plan

  - [x] 2 new guard tests pass
  - [x] All 16 failures in affected test files are pre-existing (verified on unmodified main)
