### PR TITLE
fix(security): add CSRF header to summarization fetch calls

### DIFF
--- a/tests/test_csrf_middleware.py
+++ b/tests/test_csrf_middleware.py
@@ -142,3 +142,25 @@ class TestCSRFMiddleware:
         """POST to sync without header should be rejected."""
         response = bare_client.post("/api/sync/full")
         assert response.status_code == 403
+
+    def test_summarization_task_post_without_csrf_rejected(self, bare_client):
+        """POST to create summarization task without header should be rejected."""
+        response = bare_client.post(
+            "/api/summarization/tasks",
+            json={"start_date": "2024-01-01", "end_date": "2024-01-07", "summary_type": "weekly"},
+        )
+        assert response.status_code == 403
+
+    def test_summarization_cancel_post_without_csrf_rejected(self, bare_client):
+        """POST to cancel summarization task without header should be rejected."""
+        response = bare_client.post("/api/summarization/tasks/fake-id/cancel")
+        assert response.status_code == 403
+
+    def test_summarization_task_post_with_csrf_allowed(self, client):
+        """POST to create summarization task with header should pass CSRF check."""
+        response = client.post(
+            "/api/summarization/tasks",
+            json={"start_date": "2024-01-01", "end_date": "2024-01-07", "summary_type": "weekly"},
+        )
+        # Should not be 403 — CSRF passes; may fail for other reasons (e.g. no LLM configured)
+        assert response.status_code != 403

--- a/web/static/js/summarization.js
+++ b/web/static/js/summarization.js
@@ -164,7 +164,8 @@ class SummarizationInterface {
             const response = await fetch('/api/summarization/tasks', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 },
                 body: JSON.stringify(formData)
             });
@@ -365,7 +366,10 @@ class SummarizationInterface {
             const taskId = taskIds[0]; // Cancel the first active task
 
             const response = await fetch(`/api/summarization/tasks/${taskId}/cancel`, {
-                method: 'POST'
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
             });
 
             if (response.ok) {


### PR DESCRIPTION
## Summary
  - `summarization.js` used raw `fetch()` without the `X-Requested-With` header that `CSRFMiddleware` requires, causing 403 on task creation and cancellation
  - Added the missing header to `createSummaryTask` and `cancelCurrentTask`
  - Added 3 CSRF tests covering summarization endpoints (all 18 pass)

  Fixes Chainlink #35

  ## Test plan
  - [x] All 18 CSRF middleware tests pass
  - [ ] Manually verify summarization task creation no longer returns 403
  - [ ] Verify task cancellation works

Chainlink: #35