### PR TITLE
fix(csrf): add missing X-Requested-With header to all raw fetch() calls

### DIFF
--- a/tests/test_csrf_client_headers.py
+++ b/tests/test_csrf_client_headers.py
@@ -1,0 +1,94 @@
+# ABOUTME: Tests that client-side JavaScript includes CSRF headers in state-changing fetch() calls.
+# ABOUTME: Catches regressions where raw fetch() bypasses the ApiClient's default headers.
+
+"""
+Tests that client-side JavaScript files include the X-Requested-With CSRF header
+in all state-changing fetch() calls, preventing 403 Forbidden errors.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+JS_DIR = Path(__file__).resolve().parent.parent / "web" / "static" / "js"
+
+# Matches fetch() calls that specify a method (POST, PUT, DELETE, PATCH)
+STATE_CHANGING_FETCH_RE = re.compile(
+    r"fetch\([^)]*\{[^}]*method\s*:\s*['\"](?:POST|PUT|DELETE|PATCH)['\"]",
+    re.DOTALL,
+)
+
+# Matches X-Requested-With in a headers block
+CSRF_HEADER_RE = re.compile(r"['\"]X-Requested-With['\"]")
+
+
+def _extract_fetch_blocks(source: str) -> list[tuple[int, str]]:
+    """Extract (line_number, block_text) for each state-changing fetch() call."""
+    blocks = []
+    for match in STATE_CHANGING_FETCH_RE.finditer(source):
+        start = match.start()
+        line_no = source[:start].count("\n") + 1
+        # Grab enough context to capture the headers object
+        end = source.find(");", start)
+        if end == -1:
+            end = len(source)
+        blocks.append((line_no, source[start:end]))
+    return blocks
+
+
+class TestClientCSRFHeaders:
+    """Verify all JS fetch() calls with state-changing methods include CSRF header."""
+
+    @pytest.fixture
+    def js_files(self) -> dict[str, str]:
+        """Load all .js files from the static directory."""
+        return {
+            f.name: f.read_text()
+            for f in JS_DIR.glob("*.js")
+            if f.is_file()
+        }
+
+    def test_all_state_changing_fetches_have_csrf_header(self, js_files):
+        """Every POST/PUT/DELETE/PATCH fetch() must include X-Requested-With."""
+        violations = []
+
+        for filename, source in js_files.items():
+            # Skip api.js — it's the centralized client with correct headers
+            if filename == "api.js":
+                continue
+
+            for line_no, block in _extract_fetch_blocks(source):
+                if not CSRF_HEADER_RE.search(block):
+                    violations.append(f"{filename}:{line_no}")
+
+        assert not violations, (
+            f"State-changing fetch() calls missing X-Requested-With header: "
+            f"{', '.join(violations)}"
+        )
+
+    def test_dashboard_create_entry_has_csrf_header(self, js_files):
+        """dashboard.js createNewEntry() must include X-Requested-With."""
+        source = js_files["dashboard.js"]
+        blocks = _extract_fetch_blocks(source)
+
+        post_blocks = [b for b in blocks if "POST" in b[1]]
+        assert post_blocks, "dashboard.js should have a POST fetch() call"
+
+        for line_no, block in post_blocks:
+            assert CSRF_HEADER_RE.search(block), (
+                f"dashboard.js:{line_no} — POST fetch() missing X-Requested-With"
+            )
+
+    def test_editor_save_entry_has_csrf_header(self, js_files):
+        """editor.js saveEntry() must include X-Requested-With."""
+        source = js_files["editor.js"]
+        blocks = _extract_fetch_blocks(source)
+
+        post_blocks = [b for b in blocks if "POST" in b[1]]
+        assert post_blocks, "editor.js should have a POST fetch() call"
+
+        for line_no, block in post_blocks:
+            assert CSRF_HEADER_RE.search(block), (
+                f"editor.js:{line_no} — POST fetch() missing X-Requested-With"
+            )

--- a/web/static/js/calendar.js
+++ b/web/static/js/calendar.js
@@ -401,7 +401,8 @@ class CalendarView {
             const response = await fetch(`/api/entries/${today}`, {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 },
                 body: JSON.stringify({
                     date: today,

--- a/web/static/js/dashboard.js
+++ b/web/static/js/dashboard.js
@@ -239,7 +239,8 @@ class Dashboard {
             const response = await fetch(`/api/entries/${todayStr}`, {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 },
                 body: JSON.stringify({
                     date: todayStr,

--- a/web/static/js/editor.js
+++ b/web/static/js/editor.js
@@ -179,7 +179,8 @@ class JournalEditor {
             const response = await fetch(`/api/entries/${this.entryDate}`, {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 },
                 body: JSON.stringify({
                     date: this.entryDate,

--- a/web/static/js/settings.js
+++ b/web/static/js/settings.js
@@ -449,7 +449,8 @@ class SettingsManager {
             const response = await fetch('/api/settings/bulk-update', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 },
                 body: JSON.stringify({
                     settings: settingsToSave
@@ -475,7 +476,10 @@ class SettingsManager {
     async resetSetting(key) {
         try {
             const response = await fetch(`/api/settings/${key}/reset`, {
-                method: 'POST'
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
             });
 
             if (!response.ok) throw new Error('Failed to reset setting');
@@ -576,7 +580,8 @@ class SettingsManager {
             const response = await fetch('/api/settings/import', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 },
                 body: JSON.stringify({
                     settings: importData
@@ -617,7 +622,10 @@ class SettingsManager {
             this.showLoading('Resetting all settings...');
 
             const response = await fetch('/api/settings/reset-all', {
-                method: 'POST'
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
             });
 
             if (!response.ok) throw new Error('Failed to reset settings');
@@ -1121,7 +1129,8 @@ class SettingsManager {
             const response = await fetch('/api/settings/work-week', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 },
                 body: JSON.stringify(this.workWeekConfig)
             });
@@ -1183,7 +1192,10 @@ class SettingsManager {
             this.showLoading('Resetting work week configuration...');
 
             const response = await fetch('/api/settings/work-week/reset', {
-                method: 'POST'
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
             });
 
             if (!response.ok) throw new Error('Failed to reset work week configuration');
@@ -1216,7 +1228,8 @@ class SettingsManager {
             const response = await fetch('/api/settings/work-week/validate', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 },
                 body: JSON.stringify(configToValidate)
             });


### PR DESCRIPTION
## Summary

- Adds the `X-Requested-With: XMLHttpRequest` CSRF header to **10 raw `fetch()` calls** across 4 JavaScript files that were bypassing the `ApiClient` and hitting the `CSRFMiddleware` 403 rejection
- Files fixed: `dashboard.js`, `editor.js`, `calendar.js`, `settings.js`
- Adds a comprehensive sweep test (`test_csrf_client_headers.py`) that catches any future raw `fetch()` calls missing the header

Fixes #149

## Test plan

- [ ] Run `pytest tests/test_csrf_client_headers.py tests/test_csrf_middleware.py -v` — all 21 tests pass
- [ ] Start the web server and test each affected action in the browser:
  - [ ] Dashboard: click "New Entry" — creates entry without 403
  - [ ] Editor: type content and save — saves without 403
  - [ ] Calendar: click "New Entry" — creates entry without 403
  - [ ] Settings: save settings, reset a setting, import/export, reset all
  - [ ] Settings: save/reset/validate work week configuration
- [ ] Verify `X-Requested-With: XMLHttpRequest` header appears in browser Network tab for all POST requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)