### PR TITLE
fix(security): prevent info disclosure in API responses and error content

### DIFF
--- a/base_llm_client.py
+++ b/base_llm_client.py
@@ -158,7 +158,7 @@ Guidelines:
                 tasks=[],
                 themes=[],
                 api_call_time=call_time,
-                raw_response=f"ERROR ({error_type}): {str(e)}",
+                raw_response=f"ERROR ({error_type})",
             )
 
     def _create_analysis_prompt(self, content: str) -> str:

--- a/tests/test_base_llm_client.py
+++ b/tests/test_base_llm_client.py
@@ -279,7 +279,7 @@ class TestBaseLLMClientAnalyzeContent:
         assert result.participants == []
         assert result.tasks == []
         assert result.themes == []
-        assert "ERROR (Exception):" in result.raw_response
+        assert result.raw_response == "ERROR (Exception)"
 
     def test_failed_analysis_updates_stats(self):
         """Failed call increments total_calls and failed_calls."""

--- a/tests/test_info_disclosure_file_path.py
+++ b/tests/test_info_disclosure_file_path.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# ABOUTME: Tests that journal entry API responses do not expose server filesystem paths.
+# ABOUTME: Ensures file_path is absent from all JournalEntryResponse API payloads.
+"""
+Information Disclosure Tests for file_path in API Responses
+
+Verifies that GET endpoints for journal entries do not include a
+file_path field in their JSON responses, preventing disclosure of
+server-side filesystem layout to API consumers.
+"""
+
+import pytest
+from datetime import date, timedelta
+
+from fastapi.testclient import TestClient
+from web.app import app
+
+
+class TestFilePathNotExposedInEntryResponse:
+    """Verify file_path is absent from all journal entry API endpoints."""
+
+    def test_get_entry_by_date_excludes_file_path(self, isolated_app_client):
+        """GET /api/entries/{date} must not return file_path."""
+        client = isolated_app_client
+
+        # Create an entry so the endpoint returns data
+        entry_date = date.today() - timedelta(days=1)
+        date_str = entry_date.isoformat()
+
+        create_resp = client.post(
+            f"/api/entries/{date_str}",
+            json={"date": date_str, "content": "Test content for file_path disclosure check."},
+        )
+        assert create_resp.status_code in (200, 201), (
+            f"Entry creation failed: {create_resp.status_code} {create_resp.text}"
+        )
+
+        get_resp = client.get(f"/api/entries/{date_str}")
+        assert get_resp.status_code == 200
+
+        data = get_resp.json()
+        assert "file_path" not in data, (
+            f"file_path must not be present in GET /api/entries/{date_str} response"
+        )
+
+    def test_list_entries_excludes_file_path(self, isolated_app_client):
+        """GET /api/entries must not return file_path in any entry."""
+        client = isolated_app_client
+
+        entry_date = date.today() - timedelta(days=2)
+        date_str = entry_date.isoformat()
+
+        client.post(
+            f"/api/entries/{date_str}",
+            json={"date": date_str, "content": "Another test entry for list endpoint."},
+        )
+
+        list_resp = client.get("/api/entries")
+        assert list_resp.status_code == 200
+
+        data = list_resp.json()
+        entries = data.get("entries", [])
+        for entry in entries:
+            assert "file_path" not in entry, (
+                "file_path must not be present in any entry from GET /api/entries"
+            )
+
+    def test_recent_entries_excludes_file_path(self, isolated_app_client):
+        """GET /api/entries/recent must not return file_path in any entry."""
+        client = isolated_app_client
+
+        entry_date = date.today() - timedelta(days=3)
+        date_str = entry_date.isoformat()
+
+        client.post(
+            f"/api/entries/{date_str}",
+            json={"date": date_str, "content": "Recent entries test."},
+        )
+
+        recent_resp = client.get("/api/entries/recent")
+        assert recent_resp.status_code == 200
+
+        data = recent_resp.json()
+        entries = data.get("entries", [])
+        for entry in entries:
+            assert "file_path" not in entry, (
+                "file_path must not be present in any entry from GET /api/entries/recent"
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_info_disclosure_raw_response.py
+++ b/tests/test_info_disclosure_raw_response.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# ABOUTME: Tests that raw_response does not leak exception details on LLM API failure.
+# ABOUTME: Ensures error type is indicated without exposing ARNs, URIs, or internal paths.
+"""
+Information Disclosure Tests for raw_response Field
+
+Verifies that when an LLM API call fails, the raw_response field of
+AnalysisResult only contains a sanitized error type indicator, not the
+full exception message which could contain sensitive data such as ARNs,
+credentials, file paths, or internal URIs.
+"""
+
+import pytest
+from pathlib import Path
+
+from base_llm_client import BaseLLMClient
+from llm_data_structures import AnalysisResult
+
+
+class StubLLMClient(BaseLLMClient):
+    """Minimal concrete subclass for testing error handling in BaseLLMClient."""
+
+    def __init__(self, fail_error=None):
+        self._fail_error = fail_error or Exception("Stub API failure")
+        super().__init__()
+
+    def _make_api_call(self, prompt: str) -> str:
+        raise self._fail_error
+
+    def test_connection(self) -> bool:
+        return False
+
+    def get_provider_info(self):
+        return {"provider": "stub", "model": "test-model"}
+
+
+class TestRawResponseInfoDisclosure:
+    """Tests that sensitive exception details are not stored in raw_response."""
+
+    def test_raw_response_does_not_contain_exception_message(self):
+        """raw_response must not include the exception message text on failure."""
+        sensitive_message = "Connection failed: arn:aws:iam::123456789:role/MyRole"
+        error = ConnectionError(sensitive_message)
+        client = StubLLMClient(fail_error=error)
+
+        result = client.analyze_content("journal content", Path("/test.txt"))
+
+        assert sensitive_message not in result.raw_response
+
+    def test_raw_response_does_not_contain_file_path(self):
+        """raw_response must not leak internal file system paths."""
+        path_in_error = "Failed to open /var/run/secrets/aws/credentials"
+        error = OSError(path_in_error)
+        client = StubLLMClient(fail_error=error)
+
+        result = client.analyze_content("content", Path("/test.txt"))
+
+        assert path_in_error not in result.raw_response
+        assert "/var/run/secrets" not in result.raw_response
+
+    def test_raw_response_does_not_contain_uri(self):
+        """raw_response must not leak internal service URIs."""
+        uri_in_error = "https://internal.corp.example.com:8443/api/v2/token"
+        error = ValueError(f"Auth error at {uri_in_error}")
+        client = StubLLMClient(fail_error=error)
+
+        result = client.analyze_content("content", Path("/test.txt"))
+
+        assert uri_in_error not in result.raw_response
+        assert "internal.corp.example.com" not in result.raw_response
+
+    def test_raw_response_contains_error_type_only(self):
+        """raw_response contains just the error type name in the expected format."""
+        error = ConnectionError("arn:aws:bedrock:us-east-1::foundation-model/secret")
+        client = StubLLMClient(fail_error=error)
+
+        result = client.analyze_content("content", Path("/test.txt"))
+
+        assert result.raw_response == "ERROR (ConnectionError)"
+
+    def test_raw_response_format_for_generic_exception(self):
+        """raw_response follows ERROR (<TypeName>) format for generic Exception."""
+        client = StubLLMClient(fail_error=Exception("internal detail"))
+
+        result = client.analyze_content("content", Path("/test.txt"))
+
+        assert result.raw_response == "ERROR (Exception)"
+
+    def test_raw_response_format_for_runtime_error(self):
+        """raw_response reflects the actual exception class name."""
+        client = StubLLMClient(fail_error=RuntimeError("sensitive internal trace"))
+
+        result = client.analyze_content("content", Path("/test.txt"))
+
+        assert result.raw_response == "ERROR (RuntimeError)"
+
+    def test_failed_result_has_empty_entity_lists(self):
+        """Failure path still returns empty entity lists alongside sanitized response."""
+        client = StubLLMClient(fail_error=Exception("boom"))
+
+        result = client.analyze_content("content", Path("/fail.txt"))
+
+        assert result.projects == []
+        assert result.participants == []
+        assert result.tasks == []
+        assert result.themes == []
+
+    def test_successful_call_raw_response_unaffected(self):
+        """Success path raw_response still stores the parsed JSON entities."""
+        import json
+
+        class SuccessClient(BaseLLMClient):
+            def _make_api_call(self, prompt):
+                return json.dumps({
+                    "projects": ["Alpha"],
+                    "participants": [],
+                    "tasks": [],
+                    "themes": [],
+                })
+
+            def test_connection(self):
+                return True
+
+            def get_provider_info(self):
+                return {}
+
+        client = SuccessClient()
+        result = client.analyze_content("content", Path("/ok.txt"))
+
+        assert result.raw_response is not None
+        assert "Alpha" in result.raw_response
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/web/models/journal.py
+++ b/web/models/journal.py
@@ -55,7 +55,6 @@ class JournalEntryUpDate(BaseModel):
 class JournalEntryResponse(JournalEntryBase):
     """Model for journal entry API responses."""
     content: Optional[str] = Field(None, description="Entry content")
-    file_path: str = Field(..., description="File system path")
     week_ending_date: Date = Field(..., description="Week ending date")
     metadata: JournalEntryMetadata = Field(..., description="Entry metadata")
     

--- a/web/services/calendar_service.py
+++ b/web/services/calendar_service.py
@@ -196,7 +196,6 @@ class CalendarService(BaseService):
                         entry_metadata = {
                             "word_count": entry.word_count,
                             "has_content": entry.has_content,
-                            "file_path": entry.file_path,
                             "modified_at": entry.modified_at
                         }
             

--- a/web/services/entry_manager.py
+++ b/web/services/entry_manager.py
@@ -659,7 +659,6 @@ class EntryManager(BaseService):
             return JournalEntryResponse(
                 date=db_entry.date,
                 content=content,
-                file_path=db_entry.file_path,
                 week_ending_date=db_entry.week_ending_date,
                 metadata=metadata,
                 created_at=created_at_local,


### PR DESCRIPTION
## Summary

- **Remove `file_path` from `JournalEntryResponse`** — prevents server filesystem path disclosure to API consumers (fixes #100)
- **Sanitize `raw_response` on LLM errors** — error results now store only `ERROR (<ExceptionType>)` instead of the full exception message, which could contain ARNs, credentials, internal URIs, or file paths (fixes #102)
- **Add comprehensive test coverage** for both fixes: `test_info_disclosure_file_path.py` and `test_info_disclosure_raw_response.py`

## Test plan

- [x] `pytest tests/test_info_disclosure_file_path.py -v` — verifies `file_path` absent from all entry API endpoints (3/3 passed)
- [x] `pytest tests/test_info_disclosure_raw_response.py -v` — verifies `raw_response` contains only sanitized error type (8/8 passed)
- [x] `pytest tests/test_base_llm_client.py -v` — existing tests updated for new error format (33/33 passed)
- [ ] Verify no regressions in `pytest tests/test_web_*.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)