### PR TITLE
fix(security): add authentication to WebSocket endpoints

### DIFF
--- a/tests/test_summarization_ws_auth.py
+++ b/tests/test_summarization_ws_auth.py
@@ -1,0 +1,120 @@
+# ABOUTME: Tests that summarization WebSocket endpoints enforce authentication.
+# ABOUTME: Validates token gating on /api/summarization/ws and /api/summarization/ws/{task_id}.
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from web.api.summarization import router as summarization_router
+from web.auth import User, encode_access_token
+from config_manager import AuthConfig
+
+
+SECRET = "ws-auth-test-secret-key-32bytes!!"
+
+
+def _make_token(role: str = "user") -> str:
+    user = User(id="u1", username="tester", role=role)
+    return encode_access_token(user, SECRET, ttl_seconds=300)
+
+
+def _make_test_app(auth_enabled: bool) -> FastAPI:
+    """Create a minimal FastAPI app with the summarization router mounted."""
+    test_app = FastAPI()
+    test_app.include_router(summarization_router)
+
+    mock_service = AsyncMock()
+    mock_service.llm_client = MagicMock()  # non-None so the WS service check passes
+    mock_service.get_task_status.return_value = None
+
+    class MockState:
+        def __init__(self):
+            self.summarization_service = mock_service
+            if auth_enabled:
+                self.auth_config = AuthConfig(enabled=True, secret_key=SECRET)
+            else:
+                self.auth_config = AuthConfig(enabled=False)
+
+    test_app.state = MockState()
+    return test_app
+
+
+class TestSummarizationWebSocketAuth:
+    """Auth enforcement on /api/summarization/ws WebSocket endpoint."""
+
+    def test_ws_no_token_rejected_when_auth_enabled(self):
+        """Connection without token must be rejected with close code 4001."""
+        client = TestClient(_make_test_app(auth_enabled=True))
+        with pytest.raises(Exception):
+            with client.websocket_connect("/api/summarization/ws") as ws:
+                pass
+
+    def test_ws_invalid_token_rejected_when_auth_enabled(self):
+        """Connection with a malformed token must be rejected."""
+        client = TestClient(_make_test_app(auth_enabled=True))
+        with pytest.raises(Exception):
+            with client.websocket_connect(
+                "/api/summarization/ws?token=not.a.valid.token"
+            ) as ws:
+                pass
+
+    def test_ws_valid_token_accepted_when_auth_enabled(self):
+        """Connection with a valid token must be accepted."""
+        token = _make_token("user")
+        client = TestClient(_make_test_app(auth_enabled=True))
+        with client.websocket_connect(f"/api/summarization/ws?token={token}") as ws:
+            data = ws.receive_json()
+            assert data["type"] == "connection_status"
+            assert data["status"] == "connected"
+
+    def test_ws_no_token_accepted_when_auth_disabled(self):
+        """When auth is disabled, connection without token must be accepted."""
+        client = TestClient(_make_test_app(auth_enabled=False))
+        with client.websocket_connect("/api/summarization/ws") as ws:
+            data = ws.receive_json()
+            assert data["status"] == "connected"
+
+
+class TestSummarizationTaskWebSocketAuth:
+    """Auth enforcement on /api/summarization/ws/{task_id} WebSocket endpoint."""
+
+    TASK_ID = "test-task-000"
+
+    def test_ws_task_no_token_rejected_when_auth_enabled(self):
+        """Connection without token must be rejected with close code 4001."""
+        client = TestClient(_make_test_app(auth_enabled=True))
+        with pytest.raises(Exception):
+            with client.websocket_connect(
+                f"/api/summarization/ws/{self.TASK_ID}"
+            ) as ws:
+                pass
+
+    def test_ws_task_invalid_token_rejected_when_auth_enabled(self):
+        """Connection with a malformed token must be rejected."""
+        client = TestClient(_make_test_app(auth_enabled=True))
+        with pytest.raises(Exception):
+            with client.websocket_connect(
+                f"/api/summarization/ws/{self.TASK_ID}?token=garbage"
+            ) as ws:
+                pass
+
+    def test_ws_task_valid_token_accepted_when_auth_enabled(self):
+        """Connection with a valid token must be accepted."""
+        token = _make_token("user")
+        client = TestClient(_make_test_app(auth_enabled=True))
+        with client.websocket_connect(
+            f"/api/summarization/ws/{self.TASK_ID}?token={token}"
+        ) as ws:
+            data = ws.receive_json()
+            # Either initial_status (task found) or error (task not found) — both valid
+            assert data["type"] in ("initial_status", "error")
+
+    def test_ws_task_no_token_accepted_when_auth_disabled(self):
+        """When auth is disabled, connection without token must be accepted."""
+        client = TestClient(_make_test_app(auth_enabled=False))
+        with client.websocket_connect(
+            f"/api/summarization/ws/{self.TASK_ID}"
+        ) as ws:
+            data = ws.receive_json()
+            assert data["type"] in ("initial_status", "error")

--- a/web/api/summarization.py
+++ b/web/api/summarization.py
@@ -17,7 +17,7 @@ import asyncio
 
 from config_manager import AppConfig
 from logger import JournalSummarizerLogger, ErrorCategory
-from web.auth import get_current_user, require_admin, User
+from web.auth import get_current_user, require_admin, User, decode_access_token
 from web.services.web_summarizer import WebSummarizationService, SummaryType, SummaryTaskStatus
 from web.models.journal import SummaryRequest, SummaryTaskResponse, ProgressResponse
 
@@ -461,6 +461,18 @@ async def get_summarization_stats(
 @router.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     """WebSocket endpoint for general progress updates."""
+    auth_config = getattr(websocket.app.state, "auth_config", None)
+    if auth_config and auth_config.enabled:
+        token = websocket.query_params.get("token")
+        if not token:
+            await websocket.close(code=4001, reason="Missing token")
+            return
+        try:
+            decode_access_token(token, auth_config.secret_key)
+        except Exception:
+            await websocket.close(code=4001, reason="Invalid token")
+            return
+
     # Check if summarization service is properly configured
     try:
         summarization_service = websocket.app.state.summarization_service
@@ -471,7 +483,7 @@ async def websocket_endpoint(websocket: WebSocket):
     except Exception as e:
         await websocket.close(code=1011, reason=f"Service unavailable: {str(e)}")
         return
-    
+
     await connection_manager.connect(websocket)
     try:
         # Send initial connection status
@@ -498,6 +510,18 @@ async def websocket_endpoint(websocket: WebSocket):
 @router.websocket("/ws/{task_id}")
 async def websocket_task_endpoint(websocket: WebSocket, task_id: str):
     """WebSocket endpoint for specific task progress updates."""
+    auth_config = getattr(websocket.app.state, "auth_config", None)
+    if auth_config and auth_config.enabled:
+        token = websocket.query_params.get("token")
+        if not token:
+            await websocket.close(code=4001, reason="Missing token")
+            return
+        try:
+            decode_access_token(token, auth_config.secret_key)
+        except Exception:
+            await websocket.close(code=4001, reason="Invalid token")
+            return
+
     # Check if summarization service is properly configured
     try:
         summarization_service = websocket.app.state.summarization_service
@@ -508,7 +532,7 @@ async def websocket_task_endpoint(websocket: WebSocket, task_id: str):
     except Exception as e:
         await websocket.close(code=1011, reason=f"Service unavailable: {str(e)}")
         return
-    
+
     await connection_manager.connect(websocket, task_id)
     try:
         # Send initial task status


### PR DESCRIPTION
## Summary

- **Add token-based auth to summarization WebSocket endpoints** — both `/api/summarization/ws` and `/api/summarization/ws/{task_id}` now validate a JWT token passed via `?token=` query param when auth is enabled (fixes #104)
- Auth is skipped when `auth_config.enabled` is `False`, preserving backward compatibility for unauthenticated deployments
- Connections without a token or with an invalid token are rejected with close code `4001`
- **Add comprehensive test coverage** in `test_summarization_ws_auth.py` covering both endpoints with auth enabled/disabled, valid/invalid/missing tokens

## Test plan

- [ ] `pytest tests/test_summarization_ws_auth.py -v` — verifies token gating on both WS endpoints
- [ ] `pytest tests/test_web_*.py -v` — verify no regressions in web tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)