### PR TITLE
fix(calendar): Today button timezone fix + commit-msg hook for issue ID translation

### DIFF
--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# ABOUTME: Git commit-msg hook that translates chainlink issue IDs to GitHub numbers.
+# ABOUTME: Delegates all logic to translate_issue_ids.py.
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+    DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+HOOK_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+exec python3 "$HOOK_DIR/translate_issue_ids.py" "$1"

--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# ABOUTME: Installs tracked git hooks by creating symlinks in .git/hooks/.
+# ABOUTME: Safe to run multiple times (symlinks are idempotent via -sf).
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOKS_SRC="$REPO_ROOT/scripts/hooks"
+HOOKS_DST="$REPO_ROOT/.git/hooks"
+
+ln -sf "$HOOKS_SRC/commit-msg" "$HOOKS_DST/commit-msg"
+echo "Installed commit-msg hook → scripts/hooks/commit-msg"

--- a/scripts/hooks/translate_issue_ids.py
+++ b/scripts/hooks/translate_issue_ids.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# ABOUTME: Translates chainlink issue IDs to GitHub issue numbers in commit messages.
+# ABOUTME: Reads .chainlink/github-sync.json to build the chainlink→GitHub mapping.
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ISSUE_REF = re.compile(r"#(\d+)")
+
+
+def load_mapping(sync_json_path):
+    """Build a chainlink_id → github_number map from github-sync.json."""
+    try:
+        data = json.loads(Path(sync_json_path).read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+    mapping = {}
+
+    for gh_num_str, entry in data.get("issues", {}).items():
+        try:
+            mapping[entry["chainlink_id"]] = int(gh_num_str)
+        except (KeyError, ValueError, TypeError):
+            continue
+
+    for cl_id_str, entry in data.get("exported", {}).items():
+        try:
+            mapping[int(cl_id_str)] = entry["gh_number"]
+        except (KeyError, ValueError, TypeError):
+            continue
+
+    return mapping
+
+
+def translate_message(message, mapping):
+    """Replace #N references where N is a known chainlink ID with the GitHub number."""
+    replacements = []
+
+    def replacer(match):
+        n = int(match.group(1))
+        if n in mapping:
+            replacements.append((n, mapping[n]))
+            return f"#{mapping[n]}"
+        return match.group(0)
+
+    translated = ISSUE_REF.sub(replacer, message)
+    return translated, replacements
+
+
+def main(commit_msg_file, repo_root=None):
+    """Read commit message, translate chainlink IDs, write back."""
+    if repo_root is None:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True
+        )
+        repo_root = result.stdout.strip()
+
+    sync_path = Path(repo_root) / ".chainlink" / "github-sync.json"
+    mapping = load_mapping(sync_path)
+
+    msg_path = Path(commit_msg_file)
+    original = msg_path.read_text()
+
+    translated, replacements = translate_message(original, mapping)
+
+    if replacements:
+        for cl_id, gh_num in replacements:
+            print(f"commit-msg hook: #{cl_id} → #{gh_num}", file=sys.stderr)
+        msg_path.write_text(translated)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/tests/test_local_date_formatting.py
+++ b/tests/test_local_date_formatting.py
@@ -1,0 +1,94 @@
+# ABOUTME: Tests that client-side JavaScript uses local date formatting, not UTC.
+# ABOUTME: Prevents timezone bugs where toISOString() returns tomorrow after ~5pm local time.
+
+"""
+Tests that JavaScript files use local date components for API date strings
+instead of toISOString().split('T')[0], which returns UTC dates and causes
+the calendar 'Today' button to select the wrong date after ~5pm local time.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+JS_DIR = Path(__file__).resolve().parent.parent / "web" / "static" / "js"
+
+# Files where toISOString().split('T')[0] is acceptable (cosmetic filename use only)
+FILENAME_ONLY_ALLOWLIST = {
+    "settings.js",       # export filename: journal-settings-YYYY-MM-DD.json
+    "summarization.js",  # download filename: summary_..._YYYY-MM-DD.txt
+}
+
+# Pattern that matches the problematic toISOString().split('T')[0] usage
+TO_ISO_DATE_RE = re.compile(r"\.toISOString\(\)\.split\(['\"]T['\"]\)\[0\]")
+
+
+def _find_violations(source: str, filename: str) -> list[tuple[int, str]]:
+    """Find lines using toISOString().split('T')[0] for non-filename purposes."""
+    violations = []
+    for i, line in enumerate(source.splitlines(), start=1):
+        if TO_ISO_DATE_RE.search(line):
+            # Allow in filename-only contexts (download attribute assignments)
+            if filename in FILENAME_ONLY_ALLOWLIST and ".download" in line:
+                continue
+            violations.append((i, line.strip()))
+    return violations
+
+
+class TestLocalDateFormatting:
+    """Verify JS code uses local date components, not UTC toISOString()."""
+
+    @pytest.fixture
+    def js_files(self) -> dict[str, str]:
+        """Load all .js files from the static directory."""
+        return {
+            f.name: f.read_text()
+            for f in JS_DIR.glob("*.js")
+            if f.is_file()
+        }
+
+    def test_no_toISOString_for_api_dates(self, js_files):
+        """No JS file should use toISOString().split('T')[0] for API date parameters."""
+        all_violations = []
+
+        for filename, source in js_files.items():
+            for line_no, line_text in _find_violations(source, filename):
+                all_violations.append(f"{filename}:{line_no}: {line_text}")
+
+        assert not all_violations, (
+            "toISOString().split('T')[0] returns UTC dates, causing timezone bugs. "
+            "Use Utils.formatDate(date, 'iso') instead.\n"
+            "Violations:\n" + "\n".join(all_violations)
+        )
+
+    def test_utils_formatDate_iso_uses_local_components(self, js_files):
+        """Utils.formatDate(date, 'iso') must use getFullYear/getMonth/getDate, not toISOString."""
+        source = js_files["utils.js"]
+
+        # Find the formatDate method and extract the iso branch
+        format_date_match = re.search(
+            r"static\s+formatDate\s*\([^)]*\)\s*\{(.*?)^\s{4}\}",
+            source,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert format_date_match, "Utils.formatDate() method not found in utils.js"
+
+        method_body = format_date_match.group(1)
+
+        # The iso branch should NOT use toISOString
+        assert not TO_ISO_DATE_RE.search(method_body), (
+            "Utils.formatDate('iso') still uses toISOString().split('T')[0]. "
+            "Must use local date components (getFullYear, getMonth, getDate)."
+        )
+
+        # The iso branch SHOULD use local date accessors
+        assert "getFullYear" in method_body, (
+            "Utils.formatDate('iso') should use date.getFullYear() for local year"
+        )
+        assert "getMonth" in method_body, (
+            "Utils.formatDate('iso') should use date.getMonth() for local month"
+        )
+        assert "getDate" in method_body, (
+            "Utils.formatDate('iso') should use date.getDate() for local day"
+        )

--- a/tests/test_translate_issue_ids.py
+++ b/tests/test_translate_issue_ids.py
@@ -1,0 +1,199 @@
+# ABOUTME: Tests for the commit-msg hook's chainlink-to-GitHub issue ID translation.
+# ABOUTME: Covers mapping loading, message translation, and the main orchestrator.
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "hooks"))
+from translate_issue_ids import load_mapping, translate_message, main
+
+
+SAMPLE_SYNC = {
+    "repo": "lbnl-science-it/WorkJournalMaker",
+    "issues": {
+        "106": {"chainlink_id": 7, "updated_at": "2026-04-22T18:49:48Z", "comment_count": 0},
+        "101": {"chainlink_id": 12, "updated_at": "2026-04-22T18:49:38Z", "comment_count": 0},
+        "152": {"chainlink_id": 38, "updated_at": "2026-06-23T00:33:41Z", "comment_count": 0},
+    },
+    "exported": {
+        "35": {"gh_number": 145, "gh_url": "https://github.com/example/issues/145"},
+        "34": {"gh_number": 146, "gh_url": "https://github.com/example/issues/146"},
+    },
+}
+
+
+class TestLoadMapping:
+    def test_loads_issues_section(self, tmp_path):
+        sync_file = tmp_path / "github-sync.json"
+        data = {"repo": "test", "issues": {"106": {"chainlink_id": 7}}, "exported": {}}
+        sync_file.write_text(json.dumps(data))
+
+        mapping = load_mapping(sync_file)
+        assert mapping[7] == 106
+
+    def test_loads_exported_section(self, tmp_path):
+        sync_file = tmp_path / "github-sync.json"
+        data = {"repo": "test", "issues": {}, "exported": {"35": {"gh_number": 145}}}
+        sync_file.write_text(json.dumps(data))
+
+        mapping = load_mapping(sync_file)
+        assert mapping[35] == 145
+
+    def test_loads_both_sections_combined(self, tmp_path):
+        sync_file = tmp_path / "github-sync.json"
+        sync_file.write_text(json.dumps(SAMPLE_SYNC))
+
+        mapping = load_mapping(sync_file)
+        assert mapping[7] == 106
+        assert mapping[12] == 101
+        assert mapping[38] == 152
+        assert mapping[35] == 145
+        assert mapping[34] == 146
+
+    def test_returns_empty_dict_when_file_missing(self, tmp_path):
+        missing = tmp_path / "nonexistent.json"
+        mapping = load_mapping(missing)
+        assert mapping == {}
+
+    def test_returns_empty_dict_on_malformed_json(self, tmp_path):
+        sync_file = tmp_path / "github-sync.json"
+        sync_file.write_text("{not valid json")
+
+        mapping = load_mapping(sync_file)
+        assert mapping == {}
+
+    def test_returns_empty_dict_on_unexpected_structure(self, tmp_path):
+        sync_file = tmp_path / "github-sync.json"
+        sync_file.write_text(json.dumps({"unexpected": "structure"}))
+
+        mapping = load_mapping(sync_file)
+        assert mapping == {}
+
+    def test_handles_empty_issues_and_exported(self, tmp_path):
+        sync_file = tmp_path / "github-sync.json"
+        data = {"repo": "test", "issues": {}, "exported": {}}
+        sync_file.write_text(json.dumps(data))
+
+        mapping = load_mapping(sync_file)
+        assert mapping == {}
+
+
+class TestTranslateMessage:
+    def test_replaces_known_id_in_subject_parens(self):
+        mapping = {7: 106}
+        result, replacements = translate_message("fix: gate debug pages (#7)", mapping)
+        assert result == "fix: gate debug pages (#106)"
+        assert replacements == [(7, 106)]
+
+    def test_replaces_known_id_in_closes_syntax(self):
+        mapping = {12: 101}
+        result, _ = translate_message("Closes #12", mapping)
+        assert result == "Closes #101"
+
+    def test_leaves_unknown_id_untouched(self):
+        mapping = {7: 106}
+        result, replacements = translate_message("Fixes #999", mapping)
+        assert result == "Fixes #999"
+        assert replacements == []
+
+    def test_empty_message_returns_empty(self):
+        result, replacements = translate_message("", {7: 106})
+        assert result == ""
+        assert replacements == []
+
+    def test_no_hash_refs_returns_unchanged(self):
+        msg = "refactor: clean up logging"
+        result, replacements = translate_message(msg, {7: 106})
+        assert result == msg
+        assert replacements == []
+
+    def test_multiple_refs_in_one_message(self):
+        mapping = {7: 106, 12: 101}
+        msg = "fix: issues (#7, #12)"
+        result, replacements = translate_message(msg, mapping)
+        assert result == "fix: issues (#106, #101)"
+        assert (7, 106) in replacements
+        assert (12, 101) in replacements
+
+    def test_mix_of_known_and_unknown_ids(self):
+        mapping = {7: 106}
+        msg = "fix: issues (#7, #999)"
+        result, replacements = translate_message(msg, mapping)
+        assert result == "fix: issues (#106, #999)"
+        assert replacements == [(7, 106)]
+
+    def test_idempotent_second_pass(self):
+        mapping = {7: 106, 35: 145}
+        msg = "fix: close bug (#7)"
+        translated, _ = translate_message(msg, mapping)
+        assert translated == "fix: close bug (#106)"
+
+        second_pass, replacements = translate_message(translated, mapping)
+        assert second_pass == translated
+        assert replacements == []
+
+    def test_returns_replacement_list_with_duplicates(self):
+        mapping = {7: 106}
+        msg = "Closes #7, also refs #7"
+        result, replacements = translate_message(msg, mapping)
+        assert result == "Closes #106, also refs #106"
+        assert replacements == [(7, 106), (7, 106)]
+
+
+class TestMain:
+    def _write_sync_file(self, repo_root, data=None):
+        chainlink_dir = repo_root / ".chainlink"
+        chainlink_dir.mkdir(exist_ok=True)
+        sync_file = chainlink_dir / "github-sync.json"
+        sync_file.write_text(json.dumps(data or SAMPLE_SYNC))
+
+    def test_rewrites_commit_msg_file(self, tmp_path):
+        self._write_sync_file(tmp_path)
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("fix: gate debug pages (#7)")
+
+        exit_code = main(str(msg_file), repo_root=str(tmp_path))
+
+        assert exit_code == 0
+        assert msg_file.read_text() == "fix: gate debug pages (#106)"
+
+    def test_no_modification_when_no_mapping_file(self, tmp_path):
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        original = "fix: something (#7)"
+        msg_file.write_text(original)
+
+        exit_code = main(str(msg_file), repo_root=str(tmp_path))
+
+        assert exit_code == 0
+        assert msg_file.read_text() == original
+
+    def test_prints_translation_to_stderr(self, tmp_path, capsys):
+        self._write_sync_file(tmp_path)
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("Closes #7")
+
+        main(str(msg_file), repo_root=str(tmp_path))
+
+        captured = capsys.readouterr()
+        assert "#7" in captured.err
+        assert "#106" in captured.err
+
+    def test_returns_zero_on_success(self, tmp_path):
+        self._write_sync_file(tmp_path)
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("no refs here")
+
+        assert main(str(msg_file), repo_root=str(tmp_path)) == 0
+
+    def test_handles_empty_commit_message(self, tmp_path):
+        self._write_sync_file(tmp_path)
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("")
+
+        exit_code = main(str(msg_file), repo_root=str(tmp_path))
+
+        assert exit_code == 0
+        assert msg_file.read_text() == ""

--- a/web/static/js/calendar.js
+++ b/web/static/js/calendar.js
@@ -103,7 +103,7 @@ class CalendarView {
                 }
 
                 // Check if it has an entry
-                const dateStr = cellDate.toISOString().split('T')[0];
+                const dateStr = Utils.formatDate(cellDate, 'iso');
                 const entry = entryLookup[dateStr];
                 if (entry && entry.has_content) {
                     cssClasses.push('has-entry');
@@ -308,7 +308,7 @@ class CalendarView {
         await this.loadCalendarData();
 
         // Select today's date
-        const todayStr = today.toISOString().split('T')[0];
+        const todayStr = Utils.formatDate(today, 'iso');
         this.selectDate(todayStr);
     }
 
@@ -395,7 +395,7 @@ class CalendarView {
     }
 
     async createNewEntry() {
-        const today = new Date().toISOString().split('T')[0];
+        const today = Utils.formatDate(new Date(), 'iso');
 
         try {
             const response = await fetch(`/api/entries/${today}`, {

--- a/web/static/js/summarization.js
+++ b/web/static/js/summarization.js
@@ -84,8 +84,8 @@ class SummarizationInterface {
         const weekAgo = new Date(today);
         weekAgo.setDate(today.getDate() - 7);
 
-        document.getElementById('start-date').value = weekAgo.toISOString().split('T')[0];
-        document.getElementById('end-date').value = today.toISOString().split('T')[0];
+        document.getElementById('start-date').value = Utils.formatDate(weekAgo, 'iso');
+        document.getElementById('end-date').value = Utils.formatDate(today, 'iso');
         document.getElementById('summary-type').value = 'weekly';
     }
 

--- a/web/static/js/utils.js
+++ b/web/static/js/utils.js
@@ -9,7 +9,10 @@ class Utils {
         };
 
         if (format === 'iso') {
-            return date.toISOString().split('T')[0];
+            const year = date.getFullYear();
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
         }
 
         return date.toLocaleDateString('en-US', options[format] || options.long);


### PR DESCRIPTION
## Summary

- **Calendar "Today" button timezone fix** — `toISOString()` returns UTC, which shifts the date backward after ~5pm local time. Replaced with local date components (`getFullYear/getMonth/getDate`) across `calendar.js`, `summarization.js`, and `utils.js` (Closes #156)
- **commit-msg hook** — auto-translates chainlink issue IDs to GitHub issue numbers in commit messages by reading `.chainlink/github-sync.json`, preventing incorrect `Closes #N` references in PRs. Includes install script at `scripts/hooks/install.sh`

## Test plan

- [x] `test_local_date_formatting.py` — verifies local date components are used instead of UTC `toISOString()`
- [x] `test_translate_issue_ids.py` — 21 tests covering mapping loading, message translation, idempotency, and edge cases
- [x] End-to-end: hook correctly translated `#7 → #106` in its own commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)