### PR TITLE
fix: work week settings now persist when changed (#30)

### DIFF
--- a/tests/test_settings_management.py
+++ b/tests/test_settings_management.py
@@ -422,12 +422,36 @@ class TestSettingsAPI:
     def test_settings_health_check_endpoint(self, client):
         """Test GET /api/settings/health endpoint."""
         response = client.get("/api/settings/health")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert 'status' in data
         assert 'database_connected' in data
         assert 'settings_count' in data
+
+    def test_work_week_reset_endpoint(self, client):
+        """Test POST /api/settings/work-week/reset returns default config."""
+        # First change to non-default preset
+        client.post(
+            "/api/settings/work-week",
+            json={"preset": "sunday_thursday", "start_day": 7, "end_day": 4, "timezone": "US/Pacific"}
+        )
+
+        # Reset to defaults
+        response = client.post("/api/settings/work-week/reset")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data['preset'] == 'monday_friday'
+        assert data['start_day'] == 1
+        assert data['end_day'] == 5
+        assert data['timezone'] == 'UTC'
+
+        # Verify the reset persisted
+        get_response = client.get("/api/settings/work-week")
+        assert get_response.status_code == 200
+        get_data = get_response.json()
+        assert get_data['preset'] == 'monday_friday'
 
 class TestSettingsIntegration:
     """Test integration between settings and other components."""

--- a/tests/test_work_week_service.py
+++ b/tests/test_work_week_service.py
@@ -80,7 +80,7 @@ class TestWorkWeekConfig:
         
         config_dict = config.to_dict()
         expected = {
-            'preset': 'monday-friday',
+            'preset': 'monday_friday',
             'start_day': 1,
             'end_day': 5,
             'timezone': 'America/New_York'
@@ -90,7 +90,7 @@ class TestWorkWeekConfig:
     def test_config_from_dict(self):
         """Test configuration deserialization from dictionary."""
         data = {
-            'preset': 'sunday-thursday',
+            'preset': 'sunday_thursday',
             'start_day': 7,
             'end_day': 4,
             'timezone': 'UTC'
@@ -153,15 +153,15 @@ class TestWorkWeekService:
         """Test available presets are returned correctly."""
         presets = work_week_service.get_available_presets()
         
-        assert 'monday-friday' in presets
-        assert 'sunday-thursday' in presets
+        assert 'monday_friday' in presets
+        assert 'sunday_thursday' in presets
         assert 'custom' in presets
         
-        monday_friday = presets['monday-friday']
+        monday_friday = presets['monday_friday']
         assert monday_friday['start_day'] == 1
         assert monday_friday['end_day'] == 5
         
-        sunday_thursday = presets['sunday-thursday']
+        sunday_thursday = presets['sunday_thursday']
         assert sunday_thursday['start_day'] == 7
         assert sunday_thursday['end_day'] == 4
     
@@ -185,7 +185,7 @@ class TestWorkWeekService:
         # Test the validation logic directly instead of complex database mocking
         # Create a config that should be loaded from database
         config_data = {
-            'preset': 'sunday-thursday',
+            'preset': 'sunday_thursday',
             'start_day': 7,
             'end_day': 4,
             'timezone': None
@@ -660,7 +660,7 @@ class TestWorkWeekServiceMaintenance:
         # Test valid preset
         is_valid = work_week_service._validate_database_setting(
             work_week_service.WORK_WEEK_PRESET_KEY, 
-            "monday-friday"
+            "monday_friday"
         )
         assert is_valid == True
         
@@ -806,7 +806,7 @@ class TestWorkWeekValidationAndErrorHandling:
     def test_ui_validation_valid_input(self, work_week_service):
         """Test UI validation with valid input."""
         config_dict = {
-            'preset': 'monday-friday',
+            'preset': 'monday_friday',
             'start_day': 1,
             'end_day': 5,
             'timezone': 'UTC'
@@ -819,7 +819,7 @@ class TestWorkWeekValidationAndErrorHandling:
     def test_ui_validation_missing_fields(self, work_week_service):
         """Test UI validation with missing required fields."""
         config_dict = {
-            'preset': 'monday-friday',
+            'preset': 'monday_friday',
             # Missing start_day and end_day
             'timezone': 'UTC'
         }
@@ -833,7 +833,7 @@ class TestWorkWeekValidationAndErrorHandling:
     def test_ui_validation_invalid_types(self, work_week_service):
         """Test UI validation with invalid field types."""
         config_dict = {
-            'preset': 'monday-friday',
+            'preset': 'monday_friday',
             'start_day': 'invalid',  # Should be number
             'end_day': 5.5,         # Should be integer
             'timezone': 123         # Should be string

--- a/tests/test_work_week_settings_service.py
+++ b/tests/test_work_week_settings_service.py
@@ -360,6 +360,58 @@ async def test_work_week_settings_backward_compatibility():
         os.unlink(db_path)
 
 
+class TestWorkWeekPresetRoundTrip:
+    """Test that presets saved via SettingsService are read correctly by WorkWeekService."""
+
+    @pytest_asyncio.fixture
+    async def services(self):
+        """Create both SettingsService and WorkWeekService sharing a temp database."""
+        from web.services.work_week_service import WorkWeekService
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = f.name
+
+        db_manager = DatabaseManager(db_path)
+        await db_manager.initialize()
+
+        config = AppConfig()
+        log_config = LogConfig()
+        logger = JournalSummarizerLogger(log_config)
+
+        settings_service = SettingsService(config, logger, db_manager)
+        work_week_service = WorkWeekService(config, logger, db_manager)
+
+        yield settings_service, work_week_service
+
+        await db_manager.engine.dispose()
+        os.unlink(db_path)
+
+    @pytest.mark.asyncio
+    async def test_sunday_thursday_preset_survives_round_trip(self, services):
+        """Save sunday_thursday via SettingsService, read via WorkWeekService.
+
+        This is the core bug from GH#30: the preset was stored as 'sunday_thursday'
+        but WorkWeekPreset enum expected 'sunday-thursday', causing a silent fallback
+        to MONDAY_FRIDAY.
+        """
+        settings_service, work_week_service = services
+
+        # Save non-default preset
+        success = await settings_service.update_work_week_preset('sunday_thursday')
+        assert success is True
+
+        # Clear WorkWeekService cache so it re-reads from DB
+        work_week_service._config_cache.clear()
+
+        # Read back through WorkWeekService
+        config = await work_week_service.get_user_work_week_config()
+
+        assert config.preset.value != "monday-friday", (
+            "Preset silently fell back to monday-friday — format mismatch between services"
+        )
+        assert config.start_day == 7, f"Expected start_day=7 (Sunday), got {config.start_day}"
+        assert config.end_day == 4, f"Expected end_day=4 (Thursday), got {config.end_day}"
+
+
 if __name__ == "__main__":
     # Run tests
     pytest.main([__file__, "-v"])

--- a/web/api/settings.py
+++ b/web/api/settings.py
@@ -217,6 +217,24 @@ async def get_work_week_presets(
             detail="Failed to retrieve work week presets"
         )
 
+@router.post("/work-week/reset", response_model=WorkWeekConfigResponse)
+async def reset_work_week_configuration(
+    settings_service: SettingsService = Depends(get_settings_service),
+    user: User = Depends(require_admin)
+):
+    """Reset work week configuration to defaults (Monday-Friday, UTC)."""
+    try:
+        await settings_service.update_work_week_preset('monday_friday')
+        await settings_service.update_setting('work_week.timezone', 'UTC')
+        settings = await settings_service.get_work_week_settings()
+        return await _build_work_week_config_response(settings)
+    except Exception as e:
+        settings_service.logger.logger.error(f"Failed to reset work week configuration: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to reset work week configuration"
+        )
+
 @router.post("/work-week/validate", response_model=WorkWeekValidationResponse)
 async def validate_work_week_configuration(
     validation_request: WorkWeekValidationRequest,

--- a/web/services/work_week_service.py
+++ b/web/services/work_week_service.py
@@ -25,8 +25,8 @@ from sqlalchemy import select, update
 
 class WorkWeekPreset(Enum):
     """Predefined work week configurations."""
-    MONDAY_FRIDAY = "monday-friday"
-    SUNDAY_THURSDAY = "sunday-thursday"
+    MONDAY_FRIDAY = "monday_friday"
+    SUNDAY_THURSDAY = "sunday_thursday"
     CUSTOM = "custom"
 
 
@@ -107,7 +107,7 @@ class WorkWeekConfig:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'WorkWeekConfig':
         """Create from dictionary representation."""
-        preset = WorkWeekPreset(data.get('preset', 'monday-friday'))
+        preset = WorkWeekPreset(data.get('preset', 'monday_friday'))
         return cls(
             preset=preset,
             start_day=data.get('start_day', 1),
@@ -641,7 +641,7 @@ class WorkWeekService(BaseService):
             async with self.db_manager.get_session() as session:
                 # Check each work week setting
                 settings_to_check = [
-                    (self.WORK_WEEK_PRESET_KEY, 'monday-friday'),
+                    (self.WORK_WEEK_PRESET_KEY, 'monday_friday'),
                     (self.WORK_WEEK_START_DAY_KEY, '1'),
                     (self.WORK_WEEK_END_DAY_KEY, '5'),
                     (self.WORK_WEEK_TIMEZONE_KEY, None)

--- a/web/static/css/settings.css
+++ b/web/static/css/settings.css
@@ -330,6 +330,32 @@
     border: 1px solid rgba(255, 149, 0, 0.2);
 }
 
+/* Info Callout */
+.info-callout {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    background-color: rgba(0, 122, 255, 0.08);
+    border: 1px solid rgba(0, 122, 255, 0.2);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+}
+
+.info-callout > svg {
+    flex-shrink: 0;
+    margin-top: 2px;
+    color: rgba(0, 122, 255, 0.7);
+}
+
+.work-week-actions {
+    display: flex;
+    gap: var(--space-3);
+    margin-top: var(--space-2);
+}
+
 /* Setting Status Indicators */
 .setting-status {
     display: flex;

--- a/web/static/js/settings.js
+++ b/web/static/js/settings.js
@@ -760,7 +760,7 @@ class SettingsManager {
 
         const customFields = document.getElementById('custom-work-week-fields');
         
-        if (preset === 'CUSTOM') {
+        if (preset === 'custom') {
             // Show custom fields
             if (customFields) {
                 customFields.style.display = 'block';
@@ -778,10 +778,10 @@ class SettingsManager {
             }
 
             // Set preset values
-            if (preset === 'MONDAY_FRIDAY') {
+            if (preset === 'monday_friday') {
                 this.workWeekConfig.start_day = 1;
                 this.workWeekConfig.end_day = 5;
-            } else if (preset === 'SUNDAY_THURSDAY') {
+            } else if (preset === 'sunday_thursday') {
                 this.workWeekConfig.start_day = 7;
                 this.workWeekConfig.end_day = 4;
             }
@@ -819,7 +819,7 @@ class SettingsManager {
         const { start_day, end_day, preset } = this.workWeekConfig;
 
         // Only validate custom configurations
-        if (preset !== 'CUSTOM') {
+        if (preset !== 'custom') {
             this.updateWorkWeekValidationDisplay();
             return true;
         }
@@ -915,7 +915,7 @@ class SettingsManager {
 
         let previewHtml = '';
 
-        if (preset === 'MONDAY_FRIDAY') {
+        if (preset === 'monday_friday') {
             previewHtml = `
                 <div class="preview-header">
                     <h4>Work Week: Monday - Friday</h4>
@@ -937,7 +937,7 @@ class SettingsManager {
                     <strong>Example:</strong> An entry created on Saturday Nov 16 will be saved to the Nov 8-15 work week directory.
                 </div>
             `;
-        } else if (preset === 'SUNDAY_THURSDAY') {
+        } else if (preset === 'sunday_thursday') {
             previewHtml = `
                 <div class="preview-header">
                     <h4>Work Week: Sunday - Thursday</h4>
@@ -959,7 +959,7 @@ class SettingsManager {
                     <strong>Example:</strong> An entry created on Friday Nov 15 will be saved to the Nov 17-21 work week directory.
                 </div>
             `;
-        } else if (preset === 'CUSTOM') {
+        } else if (preset === 'custom') {
             const startDayName = dayNames[start_day] || 'Invalid';
             const endDayName = dayNames[end_day] || 'Invalid';
             
@@ -1264,21 +1264,21 @@ class SettingsManager {
             return {
                 presets: [
                     { 
-                        value: 'MONDAY_FRIDAY', 
+                        value: 'monday_friday', 
                         label: 'Monday - Friday', 
                         description: 'Standard business week (5 days)',
                         start_day: 1,
                         end_day: 5
                     },
                     { 
-                        value: 'SUNDAY_THURSDAY', 
+                        value: 'sunday_thursday', 
                         label: 'Sunday - Thursday', 
                         description: 'Middle East business week (5 days)',
                         start_day: 7,
                         end_day: 4
                     },
                     { 
-                        value: 'CUSTOM', 
+                        value: 'custom', 
                         label: 'Custom', 
                         description: 'Define your own work week schedule',
                         start_day: null,

--- a/web/static/js/settings.js
+++ b/web/static/js/settings.js
@@ -11,6 +11,13 @@ class SettingsManager {
         this.categories = {};
         this.changedSettings = new Set();
         this.currentCategory = 'filesystem';
+        this.workWeekConfig = {
+            preset: 'monday_friday',
+            start_day: 1,
+            end_day: 5,
+            timezone: 'UTC'
+        };
+        this.workWeekValidationErrors = [];
         this.syncManager = new SyncManager();
         this.init();
     }

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -206,8 +206,8 @@
                             </span>
                         </label>
                         <select id="work-week-preset" class="setting-input work-week-preset-select" aria-describedby="work-week-preset-help">
-                            <option value="monday-friday">Monday - Friday</option>
-                            <option value="sunday-thursday">Sunday - Thursday</option>
+                            <option value="monday_friday">Monday - Friday</option>
+                            <option value="sunday_thursday">Sunday - Thursday</option>
                             <option value="custom">Custom Schedule</option>
                         </select>
                         <p class="setting-description" id="work-week-preset-help">

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -216,7 +216,7 @@
                     </div>
 
                     <!-- Custom Schedule Configuration (hidden by default) -->
-                    <div class="setting-group custom-schedule" id="custom-schedule-group" style="display: none;">
+                    <div class="setting-group custom-schedule" id="custom-work-week-fields" style="display: none;">
                         <label class="setting-label">Custom Work Week</label>
                         
                         <div class="custom-schedule-inputs">
@@ -275,8 +275,26 @@
                     </div>
 
                     <!-- Validation Messages -->
-                    <div class="validation-feedback" id="work-week-validation" style="display: none;">
-                        <div class="validation-message" id="work-week-validation-message"></div>
+                    <div class="validation-feedback" id="work-week-validation">
+                    </div>
+
+                    <!-- Save / Reset Actions -->
+                    <div class="setting-group work-week-actions">
+                        <button class="btn btn-primary" id="save-work-week-btn">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" stroke="currentColor" stroke-width="2"/>
+                                <polyline points="17,21 17,13 7,13 7,21" stroke="currentColor" stroke-width="2"/>
+                                <polyline points="7,3 7,8 15,8" stroke="currentColor" stroke-width="2"/>
+                            </svg>
+                            Save Work Week
+                        </button>
+                        <button class="btn btn-secondary" id="reset-work-week-btn">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                                <polyline points="23,4 23,10 17,10" stroke="currentColor" stroke-width="2"/>
+                                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" stroke="currentColor" stroke-width="2"/>
+                            </svg>
+                            Reset to Default
+                        </button>
                     </div>
                 </div>
             </div>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -278,6 +278,23 @@
                     <div class="validation-feedback" id="work-week-validation">
                     </div>
 
+                    <!-- Change Warning -->
+                    <div class="setting-group work-week-warning">
+                        <div class="info-callout">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
+                                <line x1="12" y1="16" x2="12" y2="12" stroke="currentColor" stroke-width="2"/>
+                                <line x1="12" y1="8" x2="12.01" y2="8" stroke="currentColor" stroke-width="2"/>
+                            </svg>
+                            <div class="info-callout-content">
+                                <strong>Note:</strong> Changing the work week schedule only affects
+                                future entries. Existing files stay in their current directories.
+                                To avoid splitting a week's entries across two folders, change this
+                                setting between weeks rather than mid-week.
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Save / Reset Actions -->
                     <div class="setting-group work-week-actions">
                         <button class="btn btn-primary" id="save-work-week-btn">


### PR DESCRIPTION
## Summary

- **Root cause:** The work-week settings panel HTML was missing the Save and Reset buttons that `settings.js` wires event listeners to. The JS `getElementById` calls returned `null`, so changes to the preset were displayed in the preview but never sent to the API. Additionally, the custom schedule container had a mismatched ID (`custom-schedule-group` vs expected `custom-work-week-fields`).
- **Fix:** Added `save-work-week-btn` and `reset-work-week-btn` elements to `settings.html`, fixed the custom-fields container ID, and removed a `display:none` that was hiding the validation feedback div.
- **UX improvement:** Added an info callout warning users that changing the work week schedule only affects future entries, and recommending changes be made between weeks to avoid splitting entries across directories.

## Changes

| File | What changed |
|------|-------------|
| `web/templates/settings.html` | Added Save/Reset buttons, fixed custom-fields ID, added info callout |
| `web/static/css/settings.css` | Added `.info-callout` and `.work-week-actions` styles |
| `web/static/js/settings.js` | Initialized `workWeekConfig` in constructor, improved preset handling |
| `web/api/settings.py` | Added `/work-week/reset` endpoint |
| `web/services/work_week_service.py` | Standardized preset format to underscores |
| `tests/` | Added work-week settings integration tests, fixed test assertions |

## Test plan

- [x] 155 work-week related tests pass
- [x] Verified in browser: change preset to Sunday-Thursday → Save → reload page → preset persists
- [x] Verified Reset to Default reverts to Monday-Friday
- [x] Confirmed info callout renders with correct warning text
- [x] No JS console errors (only pre-existing CSP font warning)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)